### PR TITLE
Added Eligibility Result pages

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -5,6 +5,8 @@ import store from '@/store';
 import JobAdvert from '@/views/JobAdvert';
 import SignIn from '@/views/SignIn';
 import EligibilityChecker from '@/views/EligibilityChecker';
+import EligibilityPass from '@/views/EligibilityPass';
+import EligibilityFail from '@/views/EligibilityFail';
 
 Vue.use(Router);
 
@@ -32,6 +34,24 @@ const router = new Router({
       meta: {
         requiresAuth: true,
         title: 'Eligibility Checker',
+      },
+    },
+    {
+      path: '/eligibility-pass',
+      name: 'eligibility-pass',
+      component: EligibilityPass,
+      meta: {
+        requiresAuth: true,
+        title: 'Eligibility Pass',
+      },
+    },
+    {
+      path: '/eligibility-fail',
+      name: 'eligibility-fail',
+      component: EligibilityFail,
+      meta: {
+        requiresAuth: true,
+        title: 'Eligibility Fail',
       },
     },
     {

--- a/src/views/EligibilityChecker.vue
+++ b/src/views/EligibilityChecker.vue
@@ -148,17 +148,4 @@ export default {
     },
   },
 };
-
 </script>
-
-<style scoped>
-.govuk-hint .govuk-link {
-  text-decoration: underline;
-  color: #1d70b8;
-}
-
-.govuk-hint .govuk-link:hover {
-  text-decoration: underline;
-  color: #4c2c92;
-}
-</style>

--- a/src/views/EligibilityFail.vue
+++ b/src/views/EligibilityFail.vue
@@ -19,8 +19,6 @@
         You can continue to apply, but it might be unlikely that you'll be offered a position.
       </p>
 
-
-
       <button class="govuk-button">
         Back to JAC homepage
       </button>
@@ -37,20 +35,17 @@
 
 <script>
 
-
 export default {
-
 };
 
 </script>
 
 <style scoped>
-.govuk-hint .govuk-link {
+.govuk-link {
   text-decoration: underline;
   color: #1d70b8;
 }
-
-.govuk-hint .govuk-link:hover {
+.govuk-link:hover {
   text-decoration: underline;
   color: #4c2c92;
 }

--- a/src/views/EligibilityFail.vue
+++ b/src/views/EligibilityFail.vue
@@ -39,14 +39,3 @@ export default {
 };
 
 </script>
-
-<style scoped>
-.govuk-link {
-  text-decoration: underline;
-  color: #1d70b8;
-}
-.govuk-link:hover {
-  text-decoration: underline;
-  color: #4c2c92;
-}
-</style>

--- a/src/views/EligibilityFail.vue
+++ b/src/views/EligibilityFail.vue
@@ -1,0 +1,57 @@
+<template>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h3 class="govuk-caption-xl govuk-!-padding-bottom-5">
+        092 Registrar of Criminal Appeals, Master of the Crown Office and Queen’s Coroner &amp;
+        Attorney
+      </h3>
+
+      <h1 class="govuk-heading-xl">
+        You might not be eligible
+      </h1>
+
+      <p class="govuk-body-m">
+        Based on your answers, it looks like you do not meet
+        all the eligibility requirements for this role.
+      </p>
+
+      <p class="govuk-body">
+        You can continue to apply, but it might be unlikely that you'll be offered a position.
+      </p>
+
+
+
+      <button class="govuk-button">
+        Back to JAC homepage
+      </button>
+
+      <p class="govuk-body-m">
+        <a
+          class="govuk-link"
+          href="#"
+        >Continue to apply</a>
+      </p>
+    </div>
+  </div>
+</template>
+
+<script>
+
+
+export default {
+
+};
+
+</script>
+
+<style scoped>
+.govuk-hint .govuk-link {
+  text-decoration: underline;
+  color: #1d70b8;
+}
+
+.govuk-hint .govuk-link:hover {
+  text-decoration: underline;
+  color: #4c2c92;
+}
+</style>

--- a/src/views/EligibilityPass.vue
+++ b/src/views/EligibilityPass.vue
@@ -1,0 +1,33 @@
+<template>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h3 class="govuk-caption-xl govuk-!-padding-bottom-5">
+        092 Registrar of Criminal Appeals, Master of the Crown Office and Queen’s Coroner &amp;
+        Attorney
+      </h3>
+
+      <h1 class="govuk-heading-xl">
+        It looks like you're eligible
+      </h1>
+
+      <p class="govuk-body-m">
+        Based on your answers, it looks like you can apply for this role.
+      </p>
+
+
+
+      <button class="govuk-button">
+        Continue
+      </button>
+    </div>
+  </div>
+</template>
+
+<script>
+
+
+export default {
+
+};
+
+</script>

--- a/src/views/EligibilityPass.vue
+++ b/src/views/EligibilityPass.vue
@@ -14,8 +14,6 @@
         Based on your answers, it looks like you can apply for this role.
       </p>
 
-
-
       <button class="govuk-button">
         Continue
       </button>
@@ -25,9 +23,7 @@
 
 <script>
 
-
 export default {
-
 };
 
 </script>

--- a/src/views/JobAdvert.vue
+++ b/src/views/JobAdvert.vue
@@ -87,7 +87,10 @@
       </button>
 
       <p class="govuk-body">
-        <a href="#">Or get email updates about this role</a>
+        <a
+          class="govuk-link"
+          href="#"
+        >Or get email updates about this role</a>
       </p>
     </div>
 
@@ -97,24 +100,32 @@
       </h2>
       <p class="govuk-body">
         <a
+          class="govuk-link"
           href="https://www.judicialappointments.gov.uk/overview-selection-process"
           target="_blank"
-        >How we shortlist
-          candidates</a>
+        >
+          How we shortlist candidates
+        </a>
       </p>
+
       <p class="govuk-body">
         <a
+          class="govuk-link"
           href="https://www.judicialappointments.gov.uk/completing-your-self-assessment"
           target="_blank"
-        >How to
-          write your self-assessment competency statements</a>
+        >
+          How to write your self-assessment competency statements
+        </a>
       </p>
+
       <p class="govuk-body">
         <a
+          class="govuk-link"
           href="https://www.judicialappointments.gov.uk/references-guidance-candidates"
           target="_blank"
-        >How to
-          choose your independent assessors</a>
+        >
+          How to choose your independent assessors
+        </a>
       </p>
     </div>
   </div>

--- a/tests/unit/journeys/page-titles.spec.js
+++ b/tests/unit/journeys/page-titles.spec.js
@@ -6,6 +6,8 @@ import Vuex from 'vuex';
 const routes = [
   ['job-advert', 'Job Advert'],
   ['eligibility-checker', 'Eligibility Checker'],
+  ['eligibility-pass', 'Eligibility Pass'],
+  ['eligibility-fail', 'Eligibility Fail'],
 ];
 
 describe('Page titles', () => {

--- a/tests/unit/journeys/signin.spec.js
+++ b/tests/unit/journeys/signin.spec.js
@@ -6,6 +6,8 @@ import Vuex from 'vuex';
 const routes = [
   ['job-advert', '/job-advert'],
   ['eligibility-checker', '/eligibility-checker'],
+  ['eligibility-pass', '/eligibility-pass'],
+  ['eligibility-fail', '/eligibility-fail'],
 ];
 
 describe('Sign in journey', () => {

--- a/tests/unit/views/EligibilityFail.spec.js
+++ b/tests/unit/views/EligibilityFail.spec.js
@@ -1,0 +1,21 @@
+import EligibilityFail from '@/views/EligibilityFail';
+import { shallowMount } from '@vue/test-utils';
+
+describe('views/EligibilityFail', () => {
+  let wrapper;
+  beforeEach(() => {
+    wrapper = shallowMount(EligibilityFail);
+  });
+
+  describe('template', () => {
+    it('renders', () => {
+      expect(wrapper.exists()).toBe(true);
+    });
+
+    it('contains a <h1>', () => {
+      expect(wrapper.contains('h1')).toBe(true);
+    });
+  });
+
+
+});

--- a/tests/unit/views/EligibilityPass.spec.js
+++ b/tests/unit/views/EligibilityPass.spec.js
@@ -1,0 +1,21 @@
+import EligibilityPass from '@/views/EligibilityPass';
+import { shallowMount } from '@vue/test-utils';
+
+describe('views/EligibilityPass', () => {
+  let wrapper;
+  beforeEach(() => {
+    wrapper = shallowMount(EligibilityPass);
+  });
+
+  describe('template', () => {
+    it('renders', () => {
+      expect(wrapper.exists()).toBe(true);
+    });
+
+    it('contains a <h1>', () => {
+      expect(wrapper.contains('h1')).toBe(true);
+    });
+  });
+
+
+});


### PR DESCRIPTION
- Added an EligibilityPass and an EligibilityFail page, with matching tests.

- Added routes to the router for these pages.

All code has been linted and tests are passing.

- Not sure about the names of the pages. Pass and fail seem a bit harsh, especially considering we don't want to off put a candidate if they don't quite match the criteria, however it's all I could think of that was descriptive enough. 

- These two pages should probably be a child routes of something, perhaps the Eligibility Checker route? however I'm not sure about what's best so it may be a seperate ticket to organise the routes and set the viewing permissions as I think a non signed in user should be allowed to see these pages. 