### PR TITLE
Qualifications Page

### DIFF
--- a/src/components/RepeatableFields/Qualification.vue
+++ b/src/components/RepeatableFields/Qualification.vue
@@ -1,9 +1,8 @@
 <template>
   <div>
-
     <RadioGroup
       :id="qualificationType"
-      v-model="row.qualificationType"
+      v-model="row.type"
       label="What are you qualified as?"
       hint="Choose 1 option."
     >
@@ -27,7 +26,7 @@
 
     <RadioGroup
       :id="qualificationLocation"
-      v-model="row.qualificationLocation"
+      v-model="row.location"
       label="Where are you qualified?"
       hint="Choose 1 option."
     >
@@ -47,7 +46,7 @@
 
     <DateInput
       :id="qualificationDate"
-      v-model="row.qualificationDate"
+      v-model="row.date"
       label="When did you qualify?"
       type="month"
     />
@@ -62,7 +61,7 @@ import RadioItem from '@/components/Form/RadioItem';
 import DateInput from '@/components/Form/DateInput';
 
 export default {
-  name: 'Qualifications',
+  name: 'Qualification',
   components: {
     RadioGroup,
     RadioItem,

--- a/src/components/RepeatableFields/Qualifications.vue
+++ b/src/components/RepeatableFields/Qualifications.vue
@@ -1,0 +1,93 @@
+<template>
+  <div>
+
+    <RadioGroup
+      :id="qualificationType"
+      v-model="row.qualificationType"
+      label="What are you qualified as?"
+      hint="Choose 1 option."
+    >
+      <RadioItem
+        value="advocate-scotland"
+        label="Advocate - Scotland"
+      />
+      <RadioItem
+        value="barrister"
+        label="Barrister"
+      />
+      <RadioItem
+        value="CILEx"
+        label="Fellow of the Chartered Institute of Legal Executives (CILEx)"
+      />
+      <RadioItem
+        value="solicitor"
+        label="Solicitor"
+      />
+    </RadioGroup>
+
+    <RadioGroup
+      :id="qualificationLocation"
+      v-model="row.qualificationLocation"
+      label="Where are you qualified?"
+      hint="Choose 1 option."
+    >
+      <RadioItem
+        value="england-wales"
+        label="England and Wales"
+      />
+      <RadioItem
+        value="northern-ireland"
+        label="Northern Ireland"
+      />
+      <RadioItem
+        value="scotland"
+        label="Scotland"
+      />
+    </RadioGroup>
+
+    <DateInput
+      :id="qualificationDate"
+      v-model="row.qualificationDate"
+      label="When did you qualify?"
+      type="month"
+    />
+
+    <slot name="removeButton" />
+  </div>
+</template>
+
+<script>
+import RadioGroup from '@/components/Form/RadioGroup';
+import RadioItem from '@/components/Form/RadioItem';
+import DateInput from '@/components/Form/DateInput';
+
+export default {
+  name: 'Qualifications',
+  components: {
+    RadioGroup,
+    RadioItem,
+    DateInput,
+  },
+  props: {
+    row: {
+      required: true,
+      type: Object,
+    },
+    index: {
+      required: true,
+      type: Number,
+    },
+  },
+  computed: {
+    qualificationType() {
+      return `qualification_type_${this.index}`;
+    },
+    qualificationLocation() {
+      return `qualification_location_${this.index}`;
+    },
+    qualificationDate() {
+      return `qualification_date_${this.index}`;
+    },
+  },
+};
+</script>

--- a/src/router.js
+++ b/src/router.js
@@ -9,6 +9,7 @@ import EligibilityPass from '@/views/EligibilityPass';
 import EligibilityFail from '@/views/EligibilityFail';
 import PersonalDetails from '@/views/PersonalDetails';
 import TaskList from '@/views/TaskList';
+import Qualifications from '@/views/Qualifications';
 
 Vue.use(Router);
 
@@ -72,6 +73,15 @@ const router = new Router({
       meta: {
         requiresAuth: true,
         title: 'Task List',
+      },
+    },
+    {
+      path: '/qualifications',
+      name: 'qualifications',
+      component: Qualifications,
+      meta: {
+        requiresAuth: true,
+        title: 'Qualifications',
       },
     },
     {

--- a/src/views/Qualifications.vue
+++ b/src/views/Qualifications.vue
@@ -2,14 +2,13 @@
   <div class="govuk-grid-row">
     <form @submit.prevent="save">
       <div class="govuk-grid-column-two-thirds">
-
         <h1 class="govuk-heading-xl">
           Qualifications
         </h1>
 
         <RepeatableFields
           v-model="qualifications"
-          :component="repeatableFields.Qualifications"
+          :component="repeatableFields.Qualification"
         />
 
         <button class="govuk-button">
@@ -22,7 +21,7 @@
 
 <script>
 import RepeatableFields from '@/components/RepeatableFields';
-import Qualifications from '@/components/RepeatableFields/Qualifications';
+import Qualification from '@/components/RepeatableFields/Qualification';
 
 export default {
   components: {
@@ -31,7 +30,7 @@ export default {
   data(){
     return {
       repeatableFields: {
-        Qualifications,
+        Qualification,
       },
       qualifications: null,
     };

--- a/src/views/Qualifications.vue
+++ b/src/views/Qualifications.vue
@@ -1,0 +1,45 @@
+<template>
+  <div class="govuk-grid-row">
+    <form @submit.prevent="save">
+      <div class="govuk-grid-column-two-thirds">
+
+        <h1 class="govuk-heading-xl">
+          Qualifications
+        </h1>
+
+        <RepeatableFields
+          v-model="qualifications"
+          :component="repeatableFields.Qualifications"
+        />
+
+        <button class="govuk-button">
+          Continue
+        </button>
+      </div>
+    </form>
+  </div>
+</template>
+
+<script>
+import RepeatableFields from '@/components/RepeatableFields';
+import Qualifications from '@/components/RepeatableFields/Qualifications';
+
+export default {
+  components: {
+    RepeatableFields,
+  },
+  data(){
+    return {
+      repeatableFields: {
+        Qualifications,
+      },
+      qualifications: null,
+    };
+  },
+  methods: {
+    save() {
+
+    },
+  },
+};
+</script>

--- a/tests/unit/components/RepeatableFields/Qualification.spec.js
+++ b/tests/unit/components/RepeatableFields/Qualification.spec.js
@@ -1,0 +1,87 @@
+import { shallowMount } from '@vue/test-utils';
+import Qualification from '@/components/RepeatableFields/Qualification';
+import DateInput from '@/components/Form/DateInput';
+import RadioGroup from '@/components/Form/RadioGroup';
+import RadioItem from '@/components/Form/RadioItem';
+
+const createTestSubject = (props) => {
+  return shallowMount(Qualification, {
+    propsData: {
+      ...props,
+    },
+  });
+};
+
+describe('@/components/RepeatableFields/Qualification', () => {
+  describe('name', () => {
+    it('component name is "Qualification"', () => {
+      expect(Qualification.name).toBe('Qualification');
+    });
+  });
+
+  describe('props', () => {
+    describe('row', () => {
+      it('is required', () => {
+        let prop = Qualification.props.row;
+        expect(prop.required).toBe(true);
+      });
+
+      it('has type object', () => {
+        let prop = Qualification.props.row;
+        expect(prop.type).toBe(Object);
+      });
+    });
+
+    describe('index', () => {
+      it('is required', () => {
+        let prop = Qualification.props.index;
+        expect(prop.required).toBe(true);
+      });
+
+      it('has type number', () => {
+        let prop = Qualification.props.index;
+        expect(prop.type).toBe(Number);
+      });
+    });
+  });
+
+  describe('computed properties', () => {
+    describe('qualificationType', () => {
+      it('returns the value that is created using index', () => {
+        let wrapper = createTestSubject({ index: 4, row: {} });
+        expect(wrapper.vm.qualificationType).toBe('qualification_type_4');
+      });
+    });
+
+    describe('qualificationLocation', () => {
+      it('returns the value that is created using index', () => {
+        let wrapper = createTestSubject({ index: 5, row: {} });
+        expect(wrapper.vm.qualificationLocation).toBe('qualification_location_5');
+      });
+    });
+
+    describe('qualificationDate', () => {
+      it('returns the value that is created using index', () => {
+        let wrapper = createTestSubject({ index: 5, row: {} });
+        expect(wrapper.vm.qualificationDate).toBe('qualification_date_5');
+      });
+    });
+  });
+
+  describe('template', () => {
+    it('renders DateInput', () => {
+      let wrapper = createTestSubject({ index: 1, row: {} });
+      expect(wrapper.find(DateInput).exists()).toBe(true);
+    });
+
+    it('renders RadioGroup', () => {
+      let wrapper = createTestSubject({ index: 1, row: {} });
+      expect(wrapper.find(RadioGroup).exists()).toBe(true);
+    });
+
+    it('renders RadioItem', () => {
+      let wrapper = createTestSubject({ index: 1, row: {} });
+      expect(wrapper.find(RadioItem).exists()).toBe(true);
+    });
+  });
+});

--- a/tests/unit/journeys/page-titles.spec.js
+++ b/tests/unit/journeys/page-titles.spec.js
@@ -10,6 +10,7 @@ const routes = [
   ['eligibility-fail', 'Eligibility Fail'],
   ['personal-details', 'Personal Details'],
   ['task-list', 'Task List'],
+  ['qualifications', 'Qualifications'],
 ];
 
 describe('Page titles', () => {

--- a/tests/unit/journeys/signin.spec.js
+++ b/tests/unit/journeys/signin.spec.js
@@ -10,6 +10,7 @@ const routes = [
   ['eligibility-fail', '/eligibility-fail'],
   ['personal-details', '/personal-details'],
   ['task-list', '/task-list'],
+  ['qualifications', '/qualifications'],
 ];
 
 describe('Sign in journey', () => {

--- a/tests/unit/views/Qualifications.spec.js
+++ b/tests/unit/views/Qualifications.spec.js
@@ -1,0 +1,38 @@
+import Qualifications from '@/views/Qualifications';
+import { shallowMount } from '@vue/test-utils';
+import RepeatableFields from '@/components/RepeatableFields';
+
+const createTestSubject = () => {
+  return shallowMount(Qualifications);
+};
+
+describe('views/Qualifications', () => {
+  let wrapper;
+  beforeEach(() => {
+    wrapper = createTestSubject();
+  });
+
+  describe('template', () => {
+    it('renders', () => {
+      expect(wrapper.exists()).toBe(true);
+    });
+
+    it('contains a <h1>', () => {
+      expect(wrapper.contains('h1')).toBe(true);
+    });
+
+    it('contains a <form>', () => {
+      expect(wrapper.find('form').exists()).toBe(true);
+    });
+
+    it('the <form> contains a "Continue" submit button', () => {
+      const button = wrapper.find('form button');
+      expect(button.element.type).toBe('submit');
+      expect(button.text()).toBe('Continue');
+    });
+
+    it('renders the RepeatableFields components', () => {
+      expect(wrapper.find(RepeatableFields).exists()).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
- Added the scaffolding for qualifications page in line with V1.2 of the prototype. 
- Created a Qualifications repeatable fields component, as the page allows you to add multiple qualifications.
- Created tests reflecting these two new features. All code has been linted and tests are passing. 

- Do we think that the page or component needs renaming? As it's confusing with them both being called Qualification. Perhaps the page could be renamed to TasklistQualifications, seeing as it stems from this page? The file layout helps us distinguish between similar named pages in apply-admin, and I don't think we have any components named the same as their pages 🤔 let me know what you think! 

- The Qualification repeatable field has an 'add another' button, whereas the prototype specifies that the button should say 'add another qualification'. This button is administered by the RepeatableFields.vue parent component, so if I change it, it will change for all repeatable fields. Is this a problem? Is there a way around it? 

thanks 😄 