### PR TITLE
Amended the Qualifications page

### DIFF
--- a/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
+++ b/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
@@ -2,14 +2,37 @@
   <div class="govuk-grid-row">
     <form @submit.prevent="save">
       <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-xl">
+        <h1
+          v-if="unknownVariable !== 'non-legal'"
+          class="govuk-heading-xl"
+        >
           Qualifications
         </h1>
 
+        <h1
+          v-if="unknownVariable === 'non-legal'"
+          class="govuk-heading-xl"
+        >
+          Memberships
+        </h1>
+
         <RepeatableFields
+          v-if="unknownVariable !== 'non-legal'"
           v-model="qualifications"
           :component="repeatableFields.Qualification"
         />
+
+        <RadioGroup
+          v-if="unknownVariable === 'non-legal'"
+          id="professional-memberships"
+          v-model="professionalMemberships"
+          label="What professional memberships do you have?"
+        >
+          <RadioItem
+            value="option-a"
+            label="Option A"
+          />
+        </RadioGroup>
 
         <button class="govuk-button">
           Continue
@@ -22,10 +45,14 @@
 <script>
 import RepeatableFields from '@/components/RepeatableFields';
 import Qualification from '@/components/RepeatableFields/Qualification';
+import RadioItem from '@/components/Form/RadioItem';
+import RadioGroup from '@/components/Form/RadioGroup';
 
 export default {
   components: {
     RepeatableFields,
+    RadioItem,
+    RadioGroup,
   },
   data(){
     return {
@@ -33,6 +60,8 @@ export default {
         Qualification,
       },
       qualifications: null,
+      professionalMemberships: null,
+      unknownVariable: null,
     };
   },
   methods: {
@@ -42,4 +71,3 @@ export default {
   },
 };
 </script>
-

--- a/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
+++ b/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
@@ -71,11 +71,83 @@
           <RadioItem
             value="general-medical-council"
             label="General Medical Council"
-          />
+          >
+            <RadioGroup
+              id="general-medical-council-conditional-registration"
+              v-model="GeneralMedicalCouncilConditionalRegistration"
+              label="Is your registration conditional?"
+            >
+              <RadioItem
+                :value="true"
+                label="Yes (if you do have this you might not be successful in this post)"
+              >
+                <DateInput
+                  id="gmc-yes-date"
+                  v-model="gmcConditionalYesDate"
+                  label="When did you become a member?"
+                />
+                <TextField
+                  v-model="gmcConditionalYesNumber"
+                  label="Membership number?"
+                />
+                <TextField
+                  v-model="gmcConditionalYesDetails"
+                  label="Give details of the conditions and dates"
+                />
+              </RadioItem>
+              <RadioItem
+                :value="false"
+                label="No"
+              >
+                <DateInput
+                  id="gmc-no-date"
+                  v-model="gmcConditionalNoDate"
+                  label="When did you become a member?"
+                />
+                <TextField
+                  v-model="gmcConditionalNoNumber"
+                  label="Membership number?"
+                />
+              </RadioItem>
+            </RadioGroup>
+          </RadioItem>
           <RadioItem
             value="royal-college-of-psychiatrists"
-            label="Royal College of Psychaitrists"
-          />
+            label="Royal College of Psychiatrists"
+          >
+            <RadioGroup
+              id="royal-college-of-psychiatrists-fellow-3-years"
+              v-model="royalCollegePsychiatristsFellow3Years"
+              label="You have been a member or fellow for 3 years?"
+            >
+              <RadioItem
+                :value="true"
+                label="Yes"
+              >
+                <TextField
+                  v-model="rcpYesDate"
+                  label="When did you become a member?"
+                />
+                <TextField
+                  v-model="rcpYesNumber"
+                  label="Membership number?"
+                />
+              </RadioItem>
+              <RadioItem
+                :value="false"
+                label="No (if less than 3 years you might not be successful in this post)"
+              >
+                <TextField
+                  v-model="rcpNoDate"
+                  label="When did you become a member?"
+                />
+                <TextField
+                  v-model="rcpNoNumber"
+                  label="Membership number?"
+                />
+              </RadioItem>
+            </RadioGroup>
+          </RadioItem>
           <RadioItem
             value="royal-institution-of-chartered-surveyors"
             label="Royal Institution of Chartered Surveyors"
@@ -89,10 +161,6 @@
               label="Membership number?"
             />
           </RadioItem>
-          <RadioItem
-            value="royal-institute-of-british-architects"
-            label="Royal Institute of British Architects"
-          />
           <RadioItem
             value="other"
             label="Other"
@@ -126,6 +194,7 @@ import Qualification from '@/components/RepeatableFields/Qualification';
 import RadioItem from '@/components/Form/RadioItem';
 import RadioGroup from '@/components/Form/RadioGroup';
 import TextField from '@/components/Form/TextField';
+import DateInput from '@/components/Form/DateInput';
 
 export default {
   components: {
@@ -133,6 +202,7 @@ export default {
     RadioItem,
     RadioGroup,
     TextField,
+    DateInput,
   },
   data(){
     return {
@@ -141,7 +211,28 @@ export default {
       },
       qualifications: null,
       professionalMemberships: null,
+      charteredAssociationBuildingEngineersDate: null,
+      charteredAssociationBuildingEngineersNumber: null,
+      charteredInstituteBuildingDate: null,
+      charteredInstituteBuildingNumber: null,
+      charteredInstituteEnvironmentalHealthDate: null,
+      charteredInstituteEnvironmentalHealthNumber: null,
+      GeneralMedicalCouncilConditionalRegistration: null,
+      gmcConditionalYesDate: null,
+      gmcConditionalYesNumber: null,
+      gmcConditionalYesDetails: null,
+      gmcConditionalNoDate: null,
+      gmcConditionalNoNumber: null,
+      royalCollegePsychiatristsFellow3Years: null,
+      rcpYesDate: null,
+      rcpYesNumber: null,
+      rcpNoDate: null,
+      rcpNoNumber: null,
+      royalInstitutionCharteredSurveyorsDate: null,
+      royalInstitutionCharteredSurveyorsNumber: null,
       otherProfessionalMemberships: null,
+      otherProfessionalMembershipsDate: null,
+      otherProfessionalMembershipsNumber: null,
       unknownVariable: null,
     };
   },

--- a/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
+++ b/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
@@ -100,7 +100,6 @@
             <TextField
               v-model="otherProfessionalMemberships"
               label="Associations or Institutes"
-
             />
             <TextField
               v-model="otherProfessionalMembershipsDate"
@@ -133,7 +132,7 @@ export default {
     RepeatableFields,
     RadioItem,
     RadioGroup,
-    TextField
+    TextField,
   },
   data(){
     return {

--- a/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
+++ b/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
@@ -142,7 +142,7 @@ export default {
       qualifications: null,
       professionalMemberships: null,
       otherProfessionalMemberships: null,
-      unknownVariable: 'non-legal',
+      unknownVariable: null,
     };
   },
   methods: {

--- a/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
+++ b/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
@@ -29,9 +29,88 @@
           label="What professional memberships do you have?"
         >
           <RadioItem
-            value="option-a"
-            label="Option A"
+            value="chartered-association-of-building-engineers"
+            label="Chartered Association of Building Engineers"
+          >
+            <TextField
+              v-model="charteredAssociationBuildingEngineersDate"
+              label="When did you become a member?"
+            />
+            <TextField
+              v-model="charteredAssociationBuildingEngineersNumber"
+              label="Membership number?"
+            />
+          </RadioItem>
+          <RadioItem
+            value="chartered-institute-of-building"
+            label="Chartered Institute of Building"
+          >
+            <TextField
+              v-model="charteredInstituteBuildingDate"
+              label="When did you become a member?"
+            />
+            <TextField
+              v-model="charteredInstituteBuildingNumber"
+              label="Membership number?"
+            />
+          </RadioItem>
+
+          <RadioItem
+            value="chartered-institute-of-environmental-health"
+            label="Chartered Institute of Environmental Health"
+          >
+            <TextField
+              v-model="charteredInstituteEnvironmentalHealthDate"
+              label="When did you become a member?"
+            />
+            <TextField
+              v-model="charteredInstituteEnvironmentalHealthNumber"
+              label="Membership number?"
+            />
+          </RadioItem>
+          <RadioItem
+            value="general-medical-council"
+            label="General Medical Council"
           />
+          <RadioItem
+            value="royal-college-of-psychiatrists"
+            label="Royal College of Psychaitrists"
+          />
+          <RadioItem
+            value="royal-institution-of-chartered-surveyors"
+            label="Royal Institution of Chartered Surveyors"
+          >
+            <TextField
+              v-model="royalInstitutionCharteredSurveyorsDate"
+              label="When did you become a member?"
+            />
+            <TextField
+              v-model="royalInstitutionCharteredSurveyorsNumber"
+              label="Membership number?"
+            />
+          </RadioItem>
+          <RadioItem
+            value="royal-institute-of-british-architects"
+            label="Royal Institute of British Architects"
+          />
+          <RadioItem
+            value="other"
+            label="Other"
+          >
+            <TextField
+              v-model="otherProfessionalMemberships"
+              label="Associations or Institutes"
+
+            />
+            <TextField
+              v-model="otherProfessionalMembershipsDate"
+              label="When did you become a member?"
+            />
+            <TextField
+              v-model="otherProfessionalMembershipsNumber"
+              label="Membership number?"
+            />
+          </RadioItem>
         </RadioGroup>
 
         <button class="govuk-button">
@@ -47,12 +126,14 @@ import RepeatableFields from '@/components/RepeatableFields';
 import Qualification from '@/components/RepeatableFields/Qualification';
 import RadioItem from '@/components/Form/RadioItem';
 import RadioGroup from '@/components/Form/RadioGroup';
+import TextField from '@/components/Form/TextField';
 
 export default {
   components: {
     RepeatableFields,
     RadioItem,
     RadioGroup,
+    TextField
   },
   data(){
     return {
@@ -61,7 +142,8 @@ export default {
       },
       qualifications: null,
       professionalMemberships: null,
-      unknownVariable: null,
+      otherProfessionalMemberships: null,
+      unknownVariable: 'non-legal',
     };
   },
   methods: {

--- a/tests/unit/views/Apply/QualificationsAndExperience/RelevantQualifications.spec.js
+++ b/tests/unit/views/Apply/QualificationsAndExperience/RelevantQualifications.spec.js
@@ -1,6 +1,7 @@
 import RelevantQualifications from '@/views/Apply/QualificationsAndExperience/RelevantQualifications';
 import { shallowMount } from '@vue/test-utils';
 import RepeatableFields from '@/components/RepeatableFields';
+import RadioGroup from '@/components/Form/RadioGroup';
 
 const createTestSubject = () => {
   return shallowMount(RelevantQualifications);
@@ -17,8 +18,35 @@ describe('@/views/Apply/QualificationsAndExperience/RelevantQualifications', () 
       expect(wrapper.exists()).toBe(true);
     });
 
-    it('contains a <h1>', () => {
-      expect(wrapper.contains('h1')).toBe(true);
+    describe('h1', () => {
+      let h1;
+      beforeEach( () => {
+        h1 = wrapper.find('h1');
+      });
+
+      it('contains a <h1>', () => {
+        expect(wrapper.contains('h1')).toBe(true);
+      });
+
+      it('renders the h1 as `Qualifications` if the role is legal', () => {
+        wrapper.setData({ unknownVariable: 'legal' });
+          expect(h1.text()).toBe('Qualifications');
+      });
+
+      it('renders the h1 as `Qualifications` if the role is leadership', () => {
+        wrapper.setData({ unknownVariable: 'leadership' });
+          expect(h1.text()).toBe('Qualifications');
+      });
+
+      it('renders the h1 as `Qualifications` if the role is senior', () => {
+        wrapper.setData({ unknownVariable: 'senior' });
+          expect(h1.text()).toBe('Qualifications');
+      });
+
+      it('renders the h1 as `Memberships` if the role is non-legal', () => {
+        wrapper.setData({ unknownVariable: 'non-legal' });
+          expect(h1.text()).toBe('Memberships');
+      });
     });
 
     it('contains a <form>', () => {
@@ -31,8 +59,50 @@ describe('@/views/Apply/QualificationsAndExperience/RelevantQualifications', () 
       expect(button.text()).toBe('Continue');
     });
 
-    it('renders the RepeatableFields components', () => {
-      expect(wrapper.find(RepeatableFields).exists()).toBe(true);
+    describe('Qualifications - RepeatableFields', () => {
+
+      it('renders the RepeatableFields component', () => {
+        wrapper.setData({ unknownVariable: 'legal' });
+        expect(wrapper.find(RepeatableFields).exists()).toBe(true);
+      });
+
+      it('renders the RepeatableFields component if the role is leadership', () => {
+        wrapper.setData({ unknownVariable: 'leadership' });
+        expect(wrapper.find(RepeatableFields).exists()).toBe(true);
+      });
+
+      it('renders the RepeatableFields component if the role is senior', () => {
+        wrapper.setData({ unknownVariable: 'senior' });
+        expect(wrapper.find(RepeatableFields).exists()).toBe(true);
+      });
+
+      it('does not render the RepeatableFields component if the role is non-legal', () => {
+        wrapper.setData({ unknownVariable: 'non-legal' });
+        expect(wrapper.find(RepeatableFields).exists()).toBe(false);
+      });
+    });
+
+    describe('What professional memberships do you have?', () => {
+
+      it('renders the question if the role is non-legal', () => {
+        wrapper.setData({ unknownVariable: 'non-legal' });
+        expect(wrapper.find(RadioGroup).exists()).toBe(true);
+      });
+
+      it('does not render the question if the role is legal', () => {
+        wrapper.setData({ unknownVariable: 'legal' });
+        expect(wrapper.find(RadioGroup).exists()).toBe(false);
+      });
+
+      it('does not render the question if the role is leadership', () => {
+        wrapper.setData({ unknownVariable: 'leadership' });
+        expect(wrapper.find(RadioGroup).exists()).toBe(false);
+      });
+
+      it('does not render the question if the role is senior', () => {
+        wrapper.setData({ unknownVariable: 'senior' });
+        expect(wrapper.find(RadioGroup).exists()).toBe(false);
+      });
     });
   });
 });


### PR DESCRIPTION
This PR contains all amendments to the Qualifications page. This work equates to multiple tickets.

Things that have been completed:
- Title of the page changes between 'Qualifications' and 'Memberships' depending on legal/non-legal role type. 
- Qualification Repeatable Fields component and Memberships RadioGroup replace each other depending on type of exercise. 
- Memberships question contains 'click (1/2/3) and get option' conditional reveals as depicted on Miro. 

Tests have been written and are passing. 
Code has been linted