### PR TITLE
Remove sign-button on the top-right header when on the sign-in page.

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -18,7 +18,10 @@
               >
             </div>
           </div>
-          <div class="govuk-grid-column-one-third">
+          <div
+            v-if="this.$route.name !== 'sign-in'"
+            class="govuk-grid-column-one-third"
+          >
             <button
               v-if="isSignedIn"
               class="govuk-button"


### PR DESCRIPTION
- Sign in/out button only renders if the page is not the sign in page. Made with conditional rendering