### PR TITLE
Welsh question in admin and application form

### DIFF
--- a/src/filters.js
+++ b/src/filters.js
@@ -1,6 +1,6 @@
 import Vue from 'vue';
 
-Vue.filter('formatDate', 
+Vue.filter('formatDate',
 (value) => {
   if (value) {
     const objDate = new Date(Date.parse(value));
@@ -8,7 +8,7 @@ Vue.filter('formatDate',
   }
 });
 
-Vue.filter('lookup', 
+Vue.filter('lookup',
 (value) => {
   if (value) {
     const lookup = {
@@ -57,6 +57,9 @@ Vue.filter('lookup',
       'statement-of-suitability-with-skills-and-abilities': 'Statement of Suitability with skills and abilities',
       'statement-of-suitability-with-skills-and-abilities-and-cv': 'Statement of Suitability with skills and abilities and CV',
       'statement-of-eligibility': 'Statement of eligibility',
+      'read': 'Read',
+      'write': 'Write',
+      'both': 'Both',
       'none': 'None',
       // 'xxx': 'xxx',
     };

--- a/src/router.js
+++ b/src/router.js
@@ -43,6 +43,7 @@ import RelevantMemberships from '@/views/Apply/QualificationsAndExperience/Relev
 import RelevantExperience from '@/views/Apply/QualificationsAndExperience/RelevantExperience';
 import EmploymentGaps from '@/views/Apply/QualificationsAndExperience/EmploymentGaps';
 import PartTimeWorkingPreferences from '@/views/Apply/WorkingPreferences/PartTimeWorkingPreferences';
+import WelshPosts from '@/views/Apply/WorkingPreferences/WelshPosts';
 import LeadershipSuitability from '@/views/Apply/Assessments/LeadershipSuitability';
 import StatementOfSuitability from '@/views/Apply/Assessments/StatementOfSuitability';
 import Confirmation from '@/views/Apply/Confirmation';
@@ -281,6 +282,15 @@ const router = new Router({
           meta: {
             requiresAuth: true,
             title: 'Part-time working preferences',
+          },
+        },
+        {
+          path: 'welsh-posts',
+          component: WelshPosts,
+          name: 'welsh-posts',
+          meta: {
+            requiresAuth: true,
+            title: 'Welsh posts',
           },
         },
         {

--- a/src/views/Apply/TaskList.vue
+++ b/src/views/Apply/TaskList.vue
@@ -84,6 +84,27 @@ export default {
     isNonLegal() {
       return this.vacancy.typeOfExercise ==='non-legal' || this.vacancy.typeOfExercise ==='leadership-non-legal';
     },
+    isPartTimeAndWelsh() {
+      let outcome = null;
+      if (this.vacancy.isSPTWOffered && this.vacancy.welshRequirement) {
+        outcome = true;
+      }
+      return outcome;
+    },
+    isJustPartTime() {
+      let outcome = null;
+      if (this.vacancy.isSPTWOffered && (this.vacancy.welshRequirement != true)) {
+        outcome = true;
+      }
+      return outcome;
+    },
+    isJustWelsh() {
+      let outcome = null;
+      if ((this.vacancy.isSPTWOffered != true) && this.vacancy.welshRequirement) {
+        outcome = true;
+      }
+      return outcome;
+    },
     applicationProgress() {
       if (this.application && this.application.progress) {
         return this.application.progress;
@@ -102,11 +123,26 @@ export default {
             { title: 'Equality and diversity', id: 'equality-and-diversity-survey', done: this.applicationProgress.equalityAndDiversitySurvey },
           ],
         });
-        if (this.vacancy.isSPTWOffered) {
+        if (this.isPartTimeAndWelsh) {
           data.push({
             title: 'Working preferences',
             tasks: [
               { title: 'Set part-time working preferences', id: 'part-time-working-preferences', done: this.applicationProgress.partTimeWorkingPreferences },
+              { title: 'Welsh posts', id: 'welsh-posts', done: this.applicationProgress.welshPosts },
+            ],
+          });
+        } else if (this.isJustPartTime) {
+          data.push({
+            title: 'Working preferences',
+            tasks: [
+              { title: 'Set part-time working preferences', id: 'part-time-working-preferences', done: this.applicationProgress.partTimeWorkingPreferences },
+            ],
+          });
+        } else if (this.isJustWelsh) {
+          data.push({
+            title: 'Working preferences',
+            tasks: [
+              { title: 'Welsh posts', id: 'welsh-posts', done: this.applicationProgress.welshPosts },
             ],
           });
         }

--- a/src/views/Apply/TaskList.vue
+++ b/src/views/Apply/TaskList.vue
@@ -84,48 +84,6 @@ export default {
     isNonLegal() {
       return this.vacancy.typeOfExercise ==='non-legal' || this.vacancy.typeOfExercise ==='leadership-non-legal';
     },
-    isPartTimeAndWelsh() {
-      let outcome = null;
-      if (this.vacancy.isSPTWOffered && this.vacancy.welshRequirement) {
-        outcome = true;
-      }
-      return outcome;
-    },
-    isJustPartTime() {
-      let outcome = null;
-      if (this.vacancy.isSPTWOffered && (this.vacancy.welshRequirement != true)) {
-        outcome = true;
-      }
-      return outcome;
-    },
-    isJustWelsh() {
-      let outcome = null;
-      if ((this.vacancy.isSPTWOffered != true) && this.vacancy.welshRequirement) {
-        outcome = true;
-      }
-      return outcome;
-    },
-    workingPreferences(){
-      let tasklist =[];
-      if (this.isPartTimeAndWelsh) {
-        tasklist.push(
-          { title: 'Set part-time working preferences', id: 'part-time-working-preferences', done: this.applicationProgress.partTimeWorkingPreferences },
-          { title: 'Welsh posts', id: 'welsh-posts', done: this.applicationProgress.welshPosts },
-        );
-      } else if (this.isJustPartTime) {
-        tasklist.push(
-          { title: 'Set part-time working preferences', id: 'part-time-working-preferences', done: this.applicationProgress.partTimeWorkingPreferences },
-        );
-      } else if (this.isJustWelsh) {
-        tasklist.push(
-          { title: 'Welsh posts', id: 'welsh-posts', done: this.applicationProgress.welshPosts },
-        );
-      }
-      return {
-        title: 'Working preferences',
-        tasks: tasklist,
-      };
-    },
     applicationProgress() {
       if (this.application && this.application.progress) {
         return this.application.progress;
@@ -144,7 +102,20 @@ export default {
             { title: 'Equality and diversity', id: 'equality-and-diversity-survey', done: this.applicationProgress.equalityAndDiversitySurvey },
           ],
         });
-        data.push(this.workingPreferences);
+        const workingPreferencesTasklist = [];
+        if (this.vacancy.isSPTWOffered) {
+          workingPreferencesTasklist.push({ title: 'Set part-time working preferences', id: 'part-time-working-preferences', done: this.applicationProgress.partTimeWorkingPreferences });
+        }
+        if (this.vacancy.welshRequirement) {
+          workingPreferencesTasklist.push({ title: 'Welsh posts', id: 'welsh-posts', done: this.applicationProgress.welshPosts });
+        }
+        if (workingPreferencesTasklist.length > 0) {
+          data.push({
+            title: 'Working preferences',
+            tasks: workingPreferencesTasklist,
+          });
+        }
+
         if (this.isLegal) {
           data.push({
             title: 'Qualifications and experience',

--- a/src/views/Apply/TaskList.vue
+++ b/src/views/Apply/TaskList.vue
@@ -105,6 +105,27 @@ export default {
       }
       return outcome;
     },
+    workingPreferences(){
+      let tasklist =[];
+      if (this.isPartTimeAndWelsh) {
+        tasklist.push(
+          { title: 'Set part-time working preferences', id: 'part-time-working-preferences', done: this.applicationProgress.partTimeWorkingPreferences },
+          { title: 'Welsh posts', id: 'welsh-posts', done: this.applicationProgress.welshPosts },
+        );
+      } else if (this.isJustPartTime) {
+        tasklist.push(
+          { title: 'Set part-time working preferences', id: 'part-time-working-preferences', done: this.applicationProgress.partTimeWorkingPreferences },
+        );
+      } else if (this.isJustWelsh) {
+        tasklist.push(
+          { title: 'Welsh posts', id: 'welsh-posts', done: this.applicationProgress.welshPosts },
+        );
+      }
+      return {
+        title: 'Working preferences',
+        tasks: tasklist,
+      };
+    },
     applicationProgress() {
       if (this.application && this.application.progress) {
         return this.application.progress;
@@ -123,29 +144,7 @@ export default {
             { title: 'Equality and diversity', id: 'equality-and-diversity-survey', done: this.applicationProgress.equalityAndDiversitySurvey },
           ],
         });
-        if (this.isPartTimeAndWelsh) {
-          data.push({
-            title: 'Working preferences',
-            tasks: [
-              { title: 'Set part-time working preferences', id: 'part-time-working-preferences', done: this.applicationProgress.partTimeWorkingPreferences },
-              { title: 'Welsh posts', id: 'welsh-posts', done: this.applicationProgress.welshPosts },
-            ],
-          });
-        } else if (this.isJustPartTime) {
-          data.push({
-            title: 'Working preferences',
-            tasks: [
-              { title: 'Set part-time working preferences', id: 'part-time-working-preferences', done: this.applicationProgress.partTimeWorkingPreferences },
-            ],
-          });
-        } else if (this.isJustWelsh) {
-          data.push({
-            title: 'Working preferences',
-            tasks: [
-              { title: 'Welsh posts', id: 'welsh-posts', done: this.applicationProgress.welshPosts },
-            ],
-          });
-        }
+        data.push(this.workingPreferences);
         if (this.isLegal) {
           data.push({
             title: 'Qualifications and experience',

--- a/src/views/Apply/WorkingPreferences/WelshPosts.vue
+++ b/src/views/Apply/WorkingPreferences/WelshPosts.vue
@@ -1,0 +1,144 @@
+<template>
+  <div class="govuk-grid-row">
+    <form @submit.prevent="save">
+      <div class="govuk-grid-column-two-thirds">
+        <BackLink />
+        <h1 class="govuk-heading-xl">
+          Welsh posts
+        </h1>
+
+        <ErrorSummary
+          :errors="errors"
+          :show-save-button="true"
+          @save="save"
+        />
+
+        <RadioGroup
+          v-if="isWelshAdministrationRequired"
+          id="applying-for-welsh-post"
+          v-model="application.applyingForWelshPost"
+          required
+          label="Are you applying for a post in Wales?"
+        >
+          <RadioItem
+            :value="true"
+            label="Yes"
+          />
+          <RadioItem
+            :value="false"
+            label="No"
+          />
+
+          <p
+            v-if="isApplyingForWelshPost"
+            class="govuk-body"
+          >
+            During the process you may be asked questions about your
+            knowledge of the administration of justice in Wales.
+          </p>
+        </RadioGroup>
+
+        <RadioGroup
+          v-if="isSpeakWelshRequired"
+          id="speak-welsh"
+          v-model="application.canSpeakWelsh"
+          required
+          label="Can you speak Welsh?"
+          hint="You will be tested on this later in the process."
+        >
+          <RadioItem
+            :value="true"
+            label="Yes"
+          />
+          <RadioItem
+            :value="false"
+            label="No"
+          />
+        </RadioGroup>
+
+        <RadioGroup
+          v-if="isReadWriteWelshRequired"
+          id="read-and-write-welsh"
+          v-model="application.canReadAndWriteWelsh"
+          required
+          label="Can you read and write in Welsh?"
+          hint="You will be tested on this later in the process."
+        >
+          <RadioItem
+            :value="true"
+            label="Yes"
+          />
+          <RadioItem
+            :value="false"
+            label="No"
+          />
+          <RadioItem
+            value="both"
+            label="Both"
+          />
+        </RadioGroup>
+
+        <button class="govuk-button">
+          Save and continue
+        </button>
+      </div>
+    </form>
+  </div>
+</template>
+
+<script>
+import Form from '@/components/Form/Form';
+import ErrorSummary from '@/components/Form/ErrorSummary';
+import RadioGroup from '@/components/Form/RadioGroup';
+import RadioItem from '@/components/Form/RadioItem';
+import BackLink from '@/components/BackLink';
+
+export default {
+  components: {
+    ErrorSummary,
+    RadioGroup,
+    RadioItem,
+    BackLink,
+  },
+  extends: Form,
+  data(){
+    const defaults = {
+      applyingForWelshPost: null,
+      canSpeakWelsh: null,
+      canReadAndWriteWelsh: null,
+    };
+    const data = this.$store.getters['application/data']();
+    const application = { ...defaults, ...data };
+    return {
+      application: application,
+    };
+  },
+  computed: {
+    vacancy() {
+      return this.$store.state.exercise.record;
+    },
+    isWelshAdministrationRequired() {
+      return this.vacancy.welshRequirementType.includes('welsh-administration-questions');
+    },
+    isSpeakWelshRequired() {
+      return this.vacancy.welshRequirementType.includes('welsh-speaking');
+    },
+    isReadWriteWelshRequired() {
+      return this.vacancy.welshRequirementType.includes('welsh-reading-writing');
+    },
+    isApplyingForWelshPost () {
+      return this.vacancy.welshRequirement && this.application.applyingForWelshPost;
+    },
+  },
+  methods: {
+    async save() {
+      this.validate();
+      if (this.isValid()) {
+        this.application.progress.partTimeWorkingPreferences = true;
+        await this.$store.dispatch('application/save', this.application);
+        this.$router.push({ name: 'task-list' });
+      }
+    },
+  },
+};
+</script>

--- a/src/views/Apply/WorkingPreferences/WelshPosts.vue
+++ b/src/views/Apply/WorkingPreferences/WelshPosts.vue
@@ -65,12 +65,12 @@
           hint="You will be tested on this later in the process."
         >
           <RadioItem
-            :value="true"
-            label="Yes"
+            value="read"
+            label="Read"
           />
           <RadioItem
-            :value="false"
-            label="No"
+            value="write"
+            label="Write"
           />
           <RadioItem
             value="both"


### PR DESCRIPTION
Ticket: 

In Admin we need to add in additional fields to the Vacancy Information form for Welsh requirements. These will configure whether welsh questions are asked in the candidate application form.

In Candidate if the exercise has Welsh requirements we need to display a new link on the task list called Welsh Posts. This should sit under the header Working Preferences.

See the balsamic wireframe for how Candidate Welsh Posts form should work:
https://balsamiq.cloud/s156m8n/p58nrcv/r6CBD


Done: 
- Added Welsh Posts page. 
- Added rendering to the Task list. 
- Added routing.