### PR TITLE
Registration Page needs link to privacy page on new website as asking for personal data

### DIFF
--- a/src/views/SignUp.vue
+++ b/src/views/SignUp.vue
@@ -8,7 +8,7 @@
           </h1>
 
           <p class="govuk-body-l">
-            Or 
+            Or
             <RouterLink
               class="govuk-link"
               data-module="govuk-button"
@@ -16,7 +16,18 @@
             >
               sign in
             </RouterLink>
-            if you already have an account
+            if you already have an account.
+          </p>
+
+          <p class="govuk-body">
+            Find out more about how we
+            <a
+              class="govuk-link"
+              href="https://www.judicialappointments.gov.uk/accessing-your-information"
+              target="_blank"
+            >
+              process your data.
+            </a>
           </p>
 
           <div
@@ -85,7 +96,7 @@
             Continue
           </button>
         </div>
-      </form>       
+      </form>
     </div>
   </div>
 </template>
@@ -135,7 +146,7 @@ export default {
           .catch((error) => {
             this.errors.push({ ref: 'email', message: error.message });
           });
-      }  
+      }
     },
   },
 };


### PR DESCRIPTION
Underneath the heading "Creating an account" please can you enter this text:  

Find out more about how we process your data 

Please can this link (https://www.judicialappointments.gov.uk/accessing-your-information) be added to the "process your data" text