### PR TITLE
Assessments. Add new 'Reasonable length of service' form

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -42,6 +42,7 @@ import RelevantQualifications from '@/views/Apply/QualificationsAndExperience/Re
 import RelevantMemberships from '@/views/Apply/QualificationsAndExperience/RelevantMemberships';
 import RelevantExperience from '@/views/Apply/QualificationsAndExperience/RelevantExperience';
 import EmploymentGaps from '@/views/Apply/QualificationsAndExperience/EmploymentGaps';
+import ReasonableLengthOfService from '@/views/Apply/QualificationsAndExperience/ReasonableLengthOfService';
 import PartTimeWorkingPreferences from '@/views/Apply/WorkingPreferences/PartTimeWorkingPreferences';
 import WelshPosts from '@/views/Apply/WorkingPreferences/WelshPosts';
 import LeadershipSuitability from '@/views/Apply/Assessments/LeadershipSuitability';
@@ -273,6 +274,15 @@ const router = new Router({
           meta: {
             requiresAuth: true,
             title: 'Employment gaps',
+          },
+        },
+        {
+          path: 'reasonable-length-of-service',
+          component: ReasonableLengthOfService,
+          name: 'reasonable-length-of-service',
+          meta: {
+            requiresAuth: true,
+            title: 'Reasonable length of service',
           },
         },
         {

--- a/src/views/Apply/QualificationsAndExperience/ReasonableLengthOfService.vue
+++ b/src/views/Apply/QualificationsAndExperience/ReasonableLengthOfService.vue
@@ -1,0 +1,94 @@
+<template>
+  <div class="govuk-grid-row">
+    <form @submit.prevent="save">
+      <div class="govuk-grid-column-two-thirds">
+        <BackLink />
+        <h1 class="govuk-heading-xl">
+          Reasonable length of service
+        </h1>
+
+        <ErrorSummary
+          :errors="errors"
+          :show-save-button="true"
+          @save="save"
+        />
+
+        <p class="govuk-body-l">
+          Can you work for at least {{ vacancy.reasonableLengthService }} years before reaching the retirement age of {{ vacancy.retirementAge }}?
+        </p>
+
+        <RadioGroup
+          id="can-give-reasonable-los"
+          v-model="application.canGiveReasonableLOS"
+        >
+          <RadioItem
+            :value="true"
+            label="Yes"
+          />
+          <RadioItem
+            :value="false"
+            label="No"
+          >
+            <TextareaInput
+              id="cant-give-reasonable-los-details"
+              v-model="application.cantGiveReasonableLOSDetails"
+              label="You can set out here why you think you should still be considered for this role.
+              The JAC will consider it when assessing your eligibility for this role."
+            />
+          </RadioItem>
+        </RadioGroup>
+
+        <button class="govuk-button">
+          Continue
+        </button>
+      </div>
+    </form>
+  </div>
+</template>
+
+<script>
+import Form from '@/components/Form/Form';
+import ErrorSummary from '@/components/Form/ErrorSummary';
+import RadioGroup from '@/components/Form/RadioGroup';
+import RadioItem from '@/components/Form/RadioItem';
+import TextareaInput from '@/components/Form/TextareaInput';
+import BackLink from '@/components/BackLink';
+
+export default {
+  components: {
+    ErrorSummary,
+    RadioGroup,
+    RadioItem,
+    TextareaInput,
+    BackLink,
+  },
+  extends: Form,
+  data(){
+    const defaults =  {
+      canGiveReasonableLOS: null,
+      cantGiveReasonableLOSDetails: null,
+    };
+    const data = this.$store.getters['application/data']();
+    const application = { ...defaults, ...data };
+    return {
+      application: application,
+    };
+  },
+  computed: {
+    vacancy() {
+      return this.$store.state.exercise.record;
+    },
+  },
+  methods: {
+    async save() {
+      this.validate();
+      if (this.isValid()) {
+        this.application.progress.employmentGaps = true;
+        await this.$store.dispatch('application/save', this.application);
+        this.$router.push({ name: 'task-list' });
+      }
+    },
+  },
+
+};
+</script>

--- a/src/views/Apply/TaskList.vue
+++ b/src/views/Apply/TaskList.vue
@@ -125,7 +125,7 @@ export default {
               { title: 'Post-qualification work experience', id: 'post-qualification-work-experience', done: this.applicationProgress.postQualificationWorkExperience },
               { title: 'Judicial experience', id: 'judicial-experience', done: this.applicationProgress.judicialExperience },
               { title: 'Gaps in employment', id: 'employment-gaps', done: this.applicationProgress.employmentGaps },
-              { title: 'Reasonable length of service', id: 'reasonable-length-of-service', done: this.applicationProgress.ReasonableLengthOfService },
+              { title: 'Reasonable length of service', id: 'reasonable-length-of-service', done: this.applicationProgress.reasonableLengthOfService },
             ],
           });
         }
@@ -136,7 +136,7 @@ export default {
               { title: 'Relevant memberships', id: 'relevant-memberships', done: this.applicationProgress.relevantMemberships },
               { title: 'Relevant experience', id: 'relevant-experience', done: this.applicationProgress.relevantExperience },
               { title: 'Gaps in employment', id: 'employment-gaps', done: this.applicationProgress.employmentGaps },
-              { title: 'Reasonable length of service', id: 'reasonable-length-of-service', done: this.applicationProgress.ReasonableLengthOfService },
+              { title: 'Reasonable length of service', id: 'reasonable-length-of-service', done: this.applicationProgress.reasonableLengthOfService },
             ],
           });
         }

--- a/src/views/Apply/TaskList.vue
+++ b/src/views/Apply/TaskList.vue
@@ -13,6 +13,7 @@
       <h1 class="govuk-heading-xl">
         Apply for the role
       </h1>
+
       <ol class="govuk-list">
         <li
           v-for="(taskGroup, index) in taskGroups"
@@ -124,6 +125,7 @@ export default {
               { title: 'Post-qualification work experience', id: 'post-qualification-work-experience', done: this.applicationProgress.postQualificationWorkExperience },
               { title: 'Judicial experience', id: 'judicial-experience', done: this.applicationProgress.judicialExperience },
               { title: 'Gaps in employment', id: 'employment-gaps', done: this.applicationProgress.employmentGaps },
+              { title: 'Reasonable length of service', id: 'reasonable-length-of-service', done: this.applicationProgress.ReasonableLengthOfService },
             ],
           });
         }
@@ -134,6 +136,7 @@ export default {
               { title: 'Relevant memberships', id: 'relevant-memberships', done: this.applicationProgress.relevantMemberships },
               { title: 'Relevant experience', id: 'relevant-experience', done: this.applicationProgress.relevantExperience },
               { title: 'Gaps in employment', id: 'employment-gaps', done: this.applicationProgress.employmentGaps },
+              { title: 'Reasonable length of service', id: 'reasonable-length-of-service', done: this.applicationProgress.ReasonableLengthOfService },
             ],
           });
         }


### PR DESCRIPTION
Add a new form called 'Reasonable length of service' as per this wireframe:
https://balsamiq.cloud/s156m8n/p58nrcv/r9BC0

Note that the hint text should output dynamic data, based on properties of the exercise. This has already been implemented - please see file views/Eligibility/Eligibility.vue line 66

On the Task List add a link to the form within 'Assessments' section, underneath the 'independent assessors' link.



----- 

Ticket conflicted itself by asking for the link to appear in two separate sections of the task list so warren and I agreed to add it to the Memberships/Qualifications and experience blocks