### PR TITLE
Amend Salaried Part-time working page

### DIFF
--- a/src/views/Apply/WorkingPreferences/PartTimeWorkingPreferences.vue
+++ b/src/views/Apply/WorkingPreferences/PartTimeWorkingPreferences.vue
@@ -31,6 +31,7 @@
               id="part-time-working-preference-details"
               v-model="application.partTimeWorkingPreferencesDetails"
               label="With reference to the working patterns for this role, provide details of those you want to work."
+              required
             />
           </RadioItem>
           <RadioItem
@@ -70,6 +71,7 @@ export default {
   data(){
     const defaults = {
       interestedInPartTime: null,
+      partTimeWorkingPreferencesDetails: null,
     };
     const data = this.$store.getters['application/data']();
     const application = { ...defaults, ...data };

--- a/src/views/Apply/WorkingPreferences/PartTimeWorkingPreferences.vue
+++ b/src/views/Apply/WorkingPreferences/PartTimeWorkingPreferences.vue
@@ -26,7 +26,13 @@
           <RadioItem
             :value="true"
             label="Yes"
-          />
+          >
+            <TextareaInput
+              id="part-time-working-preference-details"
+              v-model="application.partTimeWorkingPreferencesDetails"
+              label="With reference to the working patterns for this role, provide details of those you want to work."
+            />
+          </RadioItem>
           <RadioItem
             :value="false"
             label="No"
@@ -49,6 +55,7 @@ import Form from '@/components/Form/Form';
 import ErrorSummary from '@/components/Form/ErrorSummary';
 import RadioGroup from '@/components/Form/RadioGroup';
 import RadioItem from '@/components/Form/RadioItem';
+import TextareaInput from '@/components/Form/TextareaInput';
 import BackLink from '@/components/BackLink';
 
 export default {
@@ -56,6 +63,7 @@ export default {
     ErrorSummary,
     RadioGroup,
     RadioItem,
+    TextareaInput,
     BackLink,
   },
   extends: Form,


### PR DESCRIPTION
@clairetroughton4 What does the last check box ask for? It's not clear

@laurenqurashi2 we need to add a text box so that candidates can outline what working pattern they would like to work.  

Essentially I want to replicate the information about Salaried Part-time working from the vacancy information page on Admin (See second Screenshot) and show it on this page.

The text box heading should be "With reference to the working patterns for this role, provide details of those you want to work"
With the text area underneath.

  