### PR TITLE
Changes to the Previous Judicial Experience Page

### DIFF
--- a/src/views/Apply/QualificationsAndExperience/JudicialExperience.vue
+++ b/src/views/Apply/QualificationsAndExperience/JudicialExperience.vue
@@ -7,6 +7,12 @@
           Judicial experience
         </h1>
 
+        <p class="govuk-body-l">
+          We need to understand how you have gained your judicial experience and
+          how many sitting days you have. Expand on the information
+          you've provided about your career.
+        </p>
+
         <ErrorSummary
           :errors="errors"
           :show-save-button="true"
@@ -14,10 +20,10 @@
         />
 
         <RadioGroup
-          id="has-been-judge"
-          v-model="application.hasBeenJudge"
+          id="fee-or-salaried-judge"
+          v-model="application.feePaidOrSalariedJudge"
           required
-          label="Have you ever been a judge?"
+          label="Are you a fee-paid or salaried judge?"
         >
           <RadioItem
             :value="true"
@@ -30,10 +36,34 @@
         </RadioGroup>
 
         <RadioGroup
-          v-if="application.hasBeenJudge === false"
-          id="similar-role"
-          v-model="application.similarRole"
-          label="Have you ever held a similar role on a quasi-judicial body?"
+          v-if="application.feePaidOrSalariedJudge === true"
+          id="fee-or-salaried-sat-thirty-days"
+          v-model="application.feePaidOrSalariedSatForThirtyDays"
+          label="Have you sat for at least 30 days?"
+        >
+          <RadioItem
+            :value="true"
+            label="Yes"
+          >
+            <TextareaInput
+              id="fee-or-salaried-sitting-days-details"
+              v-model="application.feePaidOrSalariedSittingDaysDetails"
+              label="Enter the number of sitting days for each judicial
+              appointments you have declared on this application."
+            />
+          </RadioItem>
+          <RadioItem
+            :value="false"
+            label="No"
+          />
+        </RadioGroup>
+
+        <RadioGroup
+          v-if="application.feePaidOrSalariedSatForThirtyDays == false || application.feePaidOrSalariedJudge == false"
+          id="appointment-in-quasi-judicial-body"
+          v-model="application.declaredAppointmentInQuasiJudicialBody"
+          required
+          label="Have you declared an appointment or appointments in a quasi-judicial body in this application?"
         >
           <RadioItem
             :value="true"
@@ -55,9 +85,9 @@
             </summary>
             <div class="govuk-details__text">
               <p>
-                Quasi-judicial bodies have powers and procedures similar to
-                those of courts. For example, determining facts
-                and making decisions.
+                Quasi-judicial bodies have powers and procedures
+                similar to those of courts.  For example, involve complex
+                matters, dertermining facts and making decisions.
               </p>
 
               <p>Examples of quasi-judicial bodies include:</p>
@@ -66,21 +96,33 @@
                 <li>Coroner</li>
                 <li>Parole Board</li>
                 <li>Chair of a statutory inquiry</li>
+                <li>Arbitration</li>
+                <li>Disciplinary tribunals</li>
+                <li>Conduct hearings for professional standard bodies</li>
               </ul>
             </div>
           </details>
         </RadioGroup>
 
         <RadioGroup
-          v-if="application.hasBeenJudge === true || application.hasBeenJudge === false && application.similarRole === true"
-          id="30-days-sitting"
-          v-model="application.thirtyDaysSitting"
-          label="Do you have at least 30 sitting days?"
+          v-if="application.declaredAppointmentInQuasiJudicialBody === true"
+          id="quasi-judicial-sat-thirty-days"
+          v-model="application.quasiJudicialSatForThirtyDays"
+          label="Have you sat for at least 30 days in one or all of these appointments?"
         >
           <RadioItem
             :value="true"
             label="Yes"
-          />
+          >
+            <TextareaInput
+              id="quasi-judicial-sitting-days-details"
+              v-model="application.quasiJudicialSittingDaysDetails"
+              label="Enter the number of sitting days for each of the
+              appointments you have declared on this application, and powers and
+              procedures in the office you hold. Include any further details of whether
+              a legal qualification is required, the nature of your work."
+            />
+          </RadioItem>
           <RadioItem
             :value="false"
             label="No"
@@ -88,12 +130,12 @@
         </RadioGroup>
 
         <TextareaInput
-          v-if="application.hasBeenJudge === true && application.thirtyDaysSitting === false ||
-            application.hasBeenJudge === false && application.similarRole === false ||
-            application.hasBeenJudge === false && application.similarRole === true && application.thirtyDaysSitting === false"
+          v-if="application.declaredAppointmentInQuasiJudicialBody == false ||
+            application.quasiJudicialSatForThirtyDays == false"
           id="gained-experience"
-          v-model="application.gainedExperience"
-          label="Explain how you've gained significant judicial experience."
+          v-model="application.skillsAquisitionDetails"
+          label="Provide details of how you have acquired the necessary
+          skills for this role in some other significant way."
         />
 
         <button
@@ -126,10 +168,13 @@ export default {
   extends: Form,
   data(){
     const defaults = {
-      hasBeenJudge: null,
-      thirtyDaysSitting: null,
-      similarRole: null,
-      gainedExperience: null,
+      feePaidOrSalariedJudge: null,
+      feePaidOrSalariedSatForThirtyDays: null,
+      feePaidOrSalariedSittingDaysDetails: null,
+      declaredAppointmentInQuasiJudicialBody: null,
+      quasiJudicialSatForThirtyDays: null,
+      quasiJudicialSittingDaysDetails: null,
+      skillsAquisitionDetails: null,
     };
     const data = this.$store.getters['application/data']();
     const application = { ...defaults, ...data };


### PR DESCRIPTION
Please see additional questions for the Previous Judicial Experience page

Example page on production
https://apply.judicialappointments.digital/apply/Hsqe8wYRcBnaRCxKI1Ep/judicial-experience

Please can we add the following fields and logic as set out in this wireframe.
https://balsamiq.cloud/s156m8n/p58nrcv/rAFB8


-------

Not sure my naming conventions are the best, and i could probably use a couple computed variables but I wasn't sure so let me know!