### PR TITLE
Change to the candidate confirmation page for exercise JAC00014

### DIFF
--- a/src/views/Apply/FinalCheck/Confirmation.vue
+++ b/src/views/Apply/FinalCheck/Confirmation.vue
@@ -20,17 +20,31 @@
         {{ application.personalDetails.email }}
       </p> -->
 
-      <h2 class="govuk-heading-m">
-        What happens next?
-      </h2>
+      <div v-if="vacancy.referenceNumber === 'JAC00014'">
+        <h2 class="govuk-heading-m">
+          What happens next?
+        </h2>
+
+        <p class="govuk-body">
+          We’ll contact you by 9 March 2020 to advise whether an online qualifying
+          test will be taking place. If you’ve not heard from us by this date,
+          please contact the selection exercise team.
+        </p>
+      </div>
+      <div v-else>
+        <h2 class="govuk-heading-m">
+          What happens next?
+        </h2>
+        <p class="govuk-body">
+          We'll now decide if you should be shortlisted for this role.
+        </p>
+        <p class="govuk-body">
+          We'll email you in {{ vacancy.shortlistingOutcomeDate | formatDate('month') }} to let you know either way.
+        </p>
+      </div>
+
       <p class="govuk-body">
-        We'll now decide if you should be shortlisted for this role.
-      </p>
-      <p class="govuk-body">
-        We'll email you in {{ vacancy.shortlistingOutcomeDate | formatDate('month') }} to let you know either way.
-      </p>
-      <p class="govuk-body">
-        You can view your application and apply for other vacancies from your 
+        You can view your application and apply for other vacancies from your
         <RouterLink
           class="govuk-link"
           :to="{ name: 'applications' }"
@@ -47,7 +61,7 @@ export default {
   computed: {
     vacancy () {
       return this.$store.state.vacancy.record;
-    },   
+    },
     application () {
       return this.$store.state.application.record;
     },


### PR DESCRIPTION
Is your feature request related to a problem? Please describe.
We need to make a change to the text on the for exercise JAC00014

Describe the solution you'd like
We would like to change the existing text to

"What happens next?

We’ll contact you by 9 March 2020 to advise whether an online qualifying test will be taking place.
If you’ve not heard from us by this date, please contact the selection exercise team.

You can view your application and apply for other vacancies from your dashboard."

Describe alternatives you've considered
Hard coding text with dynamic fields such as dates and process populated based on the exercise information

Additional context
Comments from colleague
The confirmation message once candidates have submitted their application gives inaccurate information. It tells candidates we will now decide whether to shortlist them for the role and we will email them either way to let them know in April 2020. We need a different message to candidates if possible. The next stage in this exercise will be for us to let them know whether they need to sit a QT as a first stage of shortlisting in March. This will depend on whether we get a sufficient number of applicants to justify running a QT.



Not sure how test this without changing my exercise's ref number. Will that cause problems? 