### PR TITLE
Quick fix - added conditional rendering to the Part time working page

### DIFF
--- a/src/views/Apply/WorkingPreferences/PartTimeWorkingPreferences.vue
+++ b/src/views/Apply/WorkingPreferences/PartTimeWorkingPreferences.vue
@@ -12,10 +12,19 @@
           :show-save-button="true"
           @save="save"
         />
+        
+        <div v-if="vacancy.referenceNumber == 'JAC00006'">
+          <p class="govuk-body-l">
+            Part-time working is available for this role, it can only be
+            accommodated by working full weeks and in block periods of at least six weeks.
+          </p>
+        </div>
 
-        <p class="govuk-body-l">
-          Part-time working is available for this role.
-        </p>
+        <div v-else>
+          <p class="govuk-body-l">
+            Part-time working is available for this role.
+          </p>
+        </div>
 
         <RadioGroup
           id="part-time-working-preferences"
@@ -28,6 +37,7 @@
             label="Yes"
           >
             <TextareaInput
+              v-if="vacancy.referenceNumber !== 'JAC00006'"
               id="part-time-working-preference-details"
               v-model="application.partTimeWorkingPreferencesDetails"
               label="With reference to the working patterns for this role, provide details of those you want to work."
@@ -78,6 +88,11 @@ export default {
     return {
       application: application,
     };
+  },
+  computed: {
+    vacancy() {
+      return this.$store.state.vacancy.record;
+    },
   },
   methods: {
     async save() {


### PR DESCRIPTION
Is your feature request related to a problem? Please describe.
We need to amend the help text for the SPTW help text on this exercise

Describe the solution you'd like
We need to change the wording to
"Part-time working is available for this role, it can only be accommodated by working full weeks and in block periods of at least six weeks."

Describe alternatives you've considered
To make the help text configurable for each exercise in future.

---------------------------

When I asked Claire for clarity, Becky responded with: 

" hope this helps but basically the team need the text underneath Part time working preferences to say....
Part-time working is available for this role, it can only be accommodated by working full weeks and in block periods of at least six weeks.
It is then just a simple yes or no without the box for comments as there is only 1 pattern. Hope that helps?"

--------------------

For this quick fix, I have added conditional rendering on the Part Time Working Preferences page to cater for the JAC00006 exercise. This changes the text and the hidden textarea in the radio group. 

