### PR TITLE
Change from vue-analytics to vue-gtag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19227,11 +19227,6 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.10.tgz",
       "integrity": "sha512-ImThpeNU9HbdZL3utgMCq0oiMzAkt1mcgy3/E6zWC/G6AaQoeuFdsl9nDhTDU3X1R6FK7nsIUuRACVcjI+A2GQ=="
     },
-    "vue-analytics": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/vue-analytics/-/vue-analytics-5.18.0.tgz",
-      "integrity": "sha512-rnDwx+4mksrwohIxqwJqRVuXotpyKjEPeqMoYveAK3vIp8MiO2BuUfVxELaPFN9/OXFt2ayuQDMParsjWDrNmA=="
-    },
     "vue-eslint-parser": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-2.0.3.tgz",
@@ -19269,6 +19264,11 @@
           }
         }
       }
+    },
+    "vue-gtag": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vue-gtag/-/vue-gtag-1.7.0.tgz",
+      "integrity": "sha512-W3bBlgzrCC1FAmhBxDhhIiaNKVoqO/VDB6ZuYGcEg0Smg88A92FUKvNgpUv1Mkn+d61pUZXBWDFKyQMkyoFU7w=="
     },
     "vue-hot-reload-api": {
       "version": "2.3.4",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "jspdf": "^1.5.3",
     "logrocket": "^1.0.6",
     "vue": "^2.6.10",
-    "vue-analytics": "^5.18.0",
+    "vue-gtag": "^1.7.0",
     "vue-router": "^3.3.4",
     "vuex": "^3.4.0",
     "vuexfire": "^3.2.2"

--- a/src/main.js
+++ b/src/main.js
@@ -4,9 +4,9 @@ import router from '@/router';
 import store from '@/store';
 import * as filters from '@/filters';
 import { auth } from '@/firebase';
-import VueAnalytics from 'vue-analytics';
 import * as Sentry from '@sentry/browser';
 import * as Integrations from '@sentry/integrations';
+import VueGtag from 'vue-gtag';
 import LogRocket from 'logrocket';
 
 if (process.env.NODE_ENV !== 'development') {
@@ -15,9 +15,10 @@ if (process.env.NODE_ENV !== 'development') {
     integrations: [new Integrations.Vue({ Vue, attachProps: true })],
   });
   LogRocket.init('vpm4kc/jac');
-  Vue.use(VueAnalytics, {
-    id: 'UA-153516887-1',
-  });
+
+  Vue.use(VueGtag, {
+    config: { id: 'UA-153516887-1' },
+  }, router);
 }
 
 Vue.config.productionTip = false;

--- a/src/router.js
+++ b/src/router.js
@@ -1,7 +1,6 @@
 import Vue from 'vue';
 import Router from 'vue-router';
 import store from '@/store';
-import VueAnalytics from 'vue-analytics';
 
 import SignIn from '@/views/SignIn';
 import SignUp from '@/views/SignUp';
@@ -503,11 +502,6 @@ const router = new Router({
       return { x: 0, y: 0 };
     }
   },
-});
-
-Vue.use(VueAnalytics, {
-  id: 'UA-153516887-1',
-  router,
 });
 
 // Global before guard to verify if a user can have access to other than sign-in pages.


### PR DESCRIPTION
Change the Google Analytics library to use `vue-gtag`. This fixes a significant number of bugs that are caused by issues in the old library! 