### PR TITLE
#308 WIP: proposed pattern for making it clear an application has closed

### DIFF
--- a/src/views/Apply/AccountProfile/EqualityAndDiversitySurvey.vue
+++ b/src/views/Apply/AccountProfile/EqualityAndDiversitySurvey.vue
@@ -683,11 +683,17 @@
         </RadioGroup>
 
         <button
+          v-if="!applicationClosed(vacancyCloseTime)"
           :disabled="application.status != 'draft'"
           class="govuk-button"
         >
           Save and continue
         </button>
+        <p
+          v-if="applicationClosed(vacancyCloseTime) && application.status == 'draft'"
+        >
+          Applications have now closed for this vaccancy. Your draft application cannot now be submitted.
+        </p>
       </div>
     </form>
   </div>
@@ -703,6 +709,7 @@ import TextareaInput from '@/components/Form/TextareaInput';
 import CheckboxGroup from '@/components/Form/CheckboxGroup';
 import CheckboxItem from '@/components/Form/CheckboxItem';
 import BackLink from '@/components/BackLink';
+import { isDateInFuture } from '@/helpers/date';
 
 export default {
   components: {
@@ -761,6 +768,9 @@ export default {
     vacancy() {
       return this.$store.state.vacancy.record;
     },
+    vacancyCloseTime() {
+      return this.$store.getters['vacancy/getCloseDate'];
+    },
     isLegal() {
       return this.vacancy.typeOfExercise ==='legal' || this.vacancy.typeOfExercise ==='leadership';
     },
@@ -775,6 +785,13 @@ export default {
         await this.$store.dispatch('candidate/saveEqualityAndDiversitySurvey', this.equalityAndDiversitySurvey);
         this.$router.push({ name: 'task-list' });
       }
+    },
+    applicationClosed(date){
+      if(date == null) return false;
+
+      const result = isDateInFuture(new Date(date));
+
+      return !result;
     },
   },
 };


### PR DESCRIPTION
A draft PR to get some suggestions. 

At the moment, when you revisit a draft application for a now closed vacancy the "Save and continue" button appears but is not clickable. This is a bit of a weird user experience and it's not clear the vacancy has closed (unless you go back one page to the TaskList view) 

This is a proposed change to replace the button at the bottom of stages in the application with some explanatory text in the case that: 
- the application has closed
- the application remained in draft

The button is disabled once the application has been submitted, but I feel that we should be more explicit when something has changed (application has closed) without a user doing anything (eg. submitting their application, for it to no longer be a draft). 

I'd also like to consider adding the `Countdown` component to all stages, so candidates can always see that when doing their application. 

I think we can make a change to all the stages by including these changes in `Apply.vue`, which is the parent. 

![Screenshot from 2020-07-10 16-56-29](https://user-images.githubusercontent.com/5859718/87174628-5ba85a00-c2cf-11ea-96ab-ca27597d73c2.png)
![Screenshot from 2020-07-10 16-56-53](https://user-images.githubusercontent.com/5859718/87174634-5e0ab400-c2cf-11ea-8c89-d529cf71d86c.png)

Let me know what you think! 