### PR TITLE
#352 - password reset UI feedback and confirmation

### DIFF
--- a/src/views/ResetPassword.vue
+++ b/src/views/ResetPassword.vue
@@ -14,8 +14,6 @@
             We'll email you a link to reset your password.
           </p>
 
-          <ErrorSummary :errors="errors" />
-
           <TextField
             id="email"
             v-model="formData.email"
@@ -33,19 +31,16 @@
 </template>
 
 <script>
-import ErrorSummary from '@/components/Form/ErrorSummary';
 import TextField from '@/components/Form/TextField';
 import { auth } from '@/firebase';
 
 export default {
   components: {
-    ErrorSummary,
     TextField,
   },
   data () {
     return {
       formData: {},
-      errors: [],
     };
   },
   methods: {
@@ -61,8 +56,8 @@ export default {
             this.$router.push({ name: 'sign-in' });
           })
           .catch((error) => {
-            // TODO: if user doesn't exist, message user and prompt to create account
-            this.errors.push({ id: 'email', message: error.message });
+            // Handled in the same way as success to prevent account enumeration attacks 
+            pass;
           });
       }
     },

--- a/src/views/ResetPassword.vue
+++ b/src/views/ResetPassword.vue
@@ -10,20 +10,37 @@
             Forgotten password
           </h1>
 
-          <p class="govuk-body-l">
-            We'll email you a link to reset your password.
-          </p>
+          <div 
+            v-if="resetSent"
+            class="govuk-panel govuk-panel--confirmation"
+          >
+            <h1 class="govuk-panel__title">
+              Please check your email
+            </h1>
+            <h2 class="govuk-panel__body govuk-!-font-size-27 govuk-!-margin-top-7">
+              If an account exists for <b>{{ formData.email }}</b>, we have now sent you a password reset link. <br>
+              Please check your junk or spam folders before contacting the JAC directly, if you don't receive this email.
+            </h2>
+          </div>
 
-          <TextField
-            id="email"
-            v-model="formData.email"
-            label="Email address"
-            type="email"
-          />
+          <div
+            v-if="!resetSent"
+          >
+            <p class="govuk-body-l">
+              We'll email you a link to reset your password.
+            </p>
 
-          <button class="govuk-button">
-            Send the link
-          </button>
+            <TextField
+              id="email"
+              v-model="formData.email"
+              label="Email address"
+              type="email"
+            />
+
+            <button class="govuk-button">
+              Send the link
+            </button>
+          </div>
         </div>
       </form>
     </div>
@@ -41,6 +58,7 @@ export default {
   data () {
     return {
       formData: {},
+      resetSent: false,
     };
   },
   methods: {
@@ -53,11 +71,11 @@ export default {
           url: returnUrl,
         })
           .then(() => {
-            this.$router.push({ name: 'sign-in' });
+            this.resetSent = true;
           })
-          .catch((error) => {
-            // Handled in the same way as success to prevent account enumeration attacks 
-            pass;
+          .catch(() => {
+            // Handled in the same way as success to prevent account enumeration attacks
+            this.resetSent = true;
           });
       }
     },


### PR DESCRIPTION
This implements a couple of things:
- Action from pentest report to remove feedback for accounts that don't exist (as it facilitates account enumeration attacks) 
- Adds success message with copy to inform users to check their mailbox, and contact the JAC if they still have issues (which solves the non-existent account problem with human intervention) 

![screenshot_2020-08-06-115624](https://user-images.githubusercontent.com/5859718/89524550-af2d9b00-d7dc-11ea-8bf0-3912a6fdfd35.png)
![screenshot_2020-08-06-115559](https://user-images.githubusercontent.com/5859718/89524560-b18ff500-d7dc-11ea-98a4-200fcfbc3e52.png)
