### PR TITLE
Feature/358/qualifying test submitted page

### DIFF
--- a/src/views/QualifyingTests/QualifyingTest.vue
+++ b/src/views/QualifyingTests/QualifyingTest.vue
@@ -21,6 +21,14 @@ export default {
   },
   mounted() {
     const id = this.$route.params.qualifyingTestId;
+    this.$store.dispatch('qualifyingTestResponses/bind').then((data) => {
+      if (data === null) {
+        this.redirectToPage();
+      }
+    }).catch((e) => {
+      this.loadFailed = true;
+      throw e;
+    });
     this.$store.dispatch('qualifyingTestResponse/bind', id)
       .then((data) => {
         if (data === null) {
@@ -35,6 +43,7 @@ export default {
       });
   },
   destroyed() {
+    this.$store.dispatch('qualifyingTestResponses/unbind');
     this.$store.dispatch('qualifyingTestResponse/unbind');
   },
   methods: {

--- a/src/views/QualifyingTests/QualifyingTest/Submitted.vue
+++ b/src/views/QualifyingTests/QualifyingTest/Submitted.vue
@@ -14,55 +14,62 @@
       <div class="govuk-fieldset__legend govuk-fieldset__legend--m govuk-!-margin-bottom-6">
         Next Steps
         <p class="govuk-body-m govuk-!-margin-top-0">
-          You will be informed of the outcome of your situational judgement qualifying test, as indicated on the <router-link :to="`/vacancy/${qualifyingTestResponse.vacancy.id}`">
+          You will be informed of the outcome of your qualifying test, as indicated on the <router-link :to="`/vacancy/${qualifyingTestResponse.vacancy.id}`">
             vacancy timeline
           </router-link>.
-          if you don't hear anything by this date, you should contact us at email@jacplaceholder.co.uk
+          <br>
+          You may now close this page. 
         </p>
       </div>
-      <div class="govuk-fieldset__legend govuk-fieldset__legend--m govuk-!-margin-bottom-6">
+      <!-- TODO: this should be a component --> 
+      <div
+        v-if="upcomingTest != false"
+        class="govuk-fieldset__legend govuk-fieldset__legend--m govuk-!-margin-bottom-6"
+      >
         You have another Qualifying Test to complete:
         <div class="govuk-inset-text">
           <a href="">
-            Critical analysis qualifying test<br>
+            {{ upcomingTest.qualifyingTest.title }}<br>
           </a>
           <strong class="red-text">
-            to be completed by TI:ME, 00th Month YEAR
+            by {{ endTime(upcomingTest) }}
           </strong>
         </div>
-      </div>
-      <div class="govuk-fieldset__legend govuk-fieldset__legend--m govuk-!-margin-bottom-6">
-        Useful links
-        <ul class="govuk-list">
-          <li>
-            <a
-              class="govuk-link"
-              href="#"
-            >
-              Back to qualifying test overview page
-            </a>
-          </li>
-          <li>
-            <a
-              class="govuk-link"
-              href="#"
-            >
-              email@jacplaceholder.co.uk
-            </a>
-          </li>
-          <li>
-            Contact number: 01234 567 891
-          </li>
-        </ul>
       </div>
     </div>
   </div>
 </template>
 <script>
+import { isToday, formatDate } from '@/helpers/date';
+
 export default {
   computed: {
     qualifyingTestResponse() {
-      return this.$store.qualifyingTestResponse.record;
+      return this.$store.state.qualifyingTestResponse.record;
+    },
+    qualifyingTestResponses() {
+      return this.$store.state.qualifyingTestResponses.records;
+    },
+    upcomingTest(){
+      for (const qt of this.qualifyingTestResponses){
+        if (qt.statusLog.completed === null){
+          return qt;
+        }
+      }
+      return false;
+    },
+  },
+  async mounted() {
+    if (this.qualifyingTestResponse.statusLog.completed === null){
+      this.qualifyingTestResponse.statusLog.completed = new Date();
+      await this.$store.dispatch('qualifyingTestResponse/save', this.qualifyingTestResponse);
+    }
+  },
+  methods: {
+    endTime(qualifyingTest){
+      const time = formatDate(qualifyingTest.qualifyingTest.endDate, 'time');
+      const day = formatDate(qualifyingTest.qualifyingTest.endDate);
+      return isToday(qualifyingTest.qualifyingTest.endDate) ? `${time} today` : `${time} on ${day}`;
     },
   },
 };

--- a/src/views/QualifyingTests/QualifyingTest/Submitted.vue
+++ b/src/views/QualifyingTests/QualifyingTest/Submitted.vue
@@ -2,22 +2,21 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <div class="govuk-!-margin-bottom-6">
-        <!-- [ Qualifying Test | Submitted | {{ $route.params.qualifyingTestId }} ] -->
         <div>
           <div class="govuk-panel govuk-panel--confirmation">
             <h1 class="govuk-panel__title">
               Test Submitted
             </h1>
-            <!-- <div class="govuk-panel__body">
-              Your reference number<br><strong>??????????</strong>
-            </div> -->
+            Your test has been submitted and is now complete.
           </div>
         </div>
       </div>
       <div class="govuk-fieldset__legend govuk-fieldset__legend--m govuk-!-margin-bottom-6">
         Next Steps
         <p class="govuk-body-m govuk-!-margin-top-0">
-          You will be informed of the outcome of your situational judgement qualifying test by <strong>[ DATE ]</strong>
+          You will be informed of the outcome of your situational judgement qualifying test, as indicated on the <router-link :to="`/vacancy/${qualifyingTestResponse.vacancy.id}`">
+            vacancy timeline
+          </router-link>.
           if you don't hear anything by this date, you should contact us at email@jacplaceholder.co.uk
         </p>
       </div>
@@ -59,7 +58,15 @@
     </div>
   </div>
 </template>
-
+<script>
+export default {
+  computed: {
+    qualifyingTestResponse() {
+      return this.$store.qualifyingTestResponse.record;
+    },
+  },
+};
+</script>
 <style>
   .govuk-inset-text {
     border-color: red;


### PR DESCRIPTION
Adds the submitted page shown to candidates when they finish their test. 

This sets the `statusLog.completed` field (if not already set). 

![screenshot_2020-08-24-172017](https://user-images.githubusercontent.com/5859718/91070217-607e5e80-e62e-11ea-862e-b318afa11a75.png)
