### PR TITLE
countdown stays at top of page

### DIFF
--- a/src/components/QualifyingTest/Countdown2.vue
+++ b/src/components/QualifyingTest/Countdown2.vue
@@ -103,6 +103,12 @@ export default {
   font-weight: bold;
   padding: 10px;
 
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  z-index: 1;
+
   span {
     font-weight: bold;
     display: inline-block;

--- a/src/views/QualifyingTests/QualifyingTest.vue
+++ b/src/views/QualifyingTests/QualifyingTest.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="govuk-grid-row">
+  <div class="qt_page">
     <LoadingMessage
       v-if="loaded === false"
       :load-failed="loadFailed"
@@ -99,3 +99,8 @@ export default {
   },
 };
 </script>
+<style scoped>
+.qt_page{
+  padding-top: 25px;
+}
+</style>


### PR DESCRIPTION
- css to make countdown stay at top of page
- removed "govuk-grid-row" from QT-top-level page which adjusts page width on fullscreen view