### PR TITLE
truncated question titles on QT overview

### DIFF
--- a/src/views/QualifyingTests/QualifyingTest/Review.vue
+++ b/src/views/QualifyingTests/QualifyingTest/Review.vue
@@ -24,7 +24,7 @@
                 :to="{ name: `qualifying-test-question`, params: { questionNumber: questionIndex + 1 } }"
                 class="moj-task-list__task-name"
               >
-                Question {{ questionIndex + 1 }}
+                {{ questionIndex + 1 }}. {{ question.details.substring(0,55) }}...
               </RouterLink>
               <strong
                 v-if="question.response.completed"


### PR DESCRIPTION
changed line
`Question. {{ questionIndex + 1 }}`
to
`{{ questionIndex + 1 }}. {{ question.details.substring(0,55) }}...`

Chose 55 chars arbitrarily as it fit the page well followed by an ellipsis appears like

"This was the question title and you must answer it by s..." 