### PR TITLE
#481 Track online presence of QT participants

### DIFF
--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -24,6 +24,16 @@ const QUALIFYING_TEST = {
   },
 };
 
+const QUALIFYING_TEST_RESPONSE = {
+  STATUS: {
+    CREATED: 'created',
+    ACTIVATED: 'activated',
+    STARTED: 'started',
+    COMPLETED: 'completed',
+    CANCELLED: 'cancelled',
+  },
+};
+
 const DEFAULT = {
   YES: 'Yes',
   NO: 'No',
@@ -32,5 +42,6 @@ const DEFAULT = {
 export {
   STATUS,
   QUALIFYING_TEST,
+  QUALIFYING_TEST_RESPONSE,
   DEFAULT
 };

--- a/src/store/connectionMonitor.js
+++ b/src/store/connectionMonitor.js
@@ -4,32 +4,35 @@
 import firebase from '@firebase/app';
 import 'firebase/database';
 
+let lastSessionPath = '';
+
 export default {
   namespaced: true,
   actions: {
     start: async (context, ref) => {
+      if (context.state.started) {
+        return;
+      }
       const userId = firebase.auth().currentUser.uid;
-      const userStatusDatabaseRef = firebase.database().ref(`/${ref}/userStatus/${userId}`);
-      const isOfflineForDatabase = {
-        state: 'offline',
-        lastUpdated: firebase.database.ServerValue.TIMESTAMP,
-      };
-      const isOnlineForDatabase = {
-        state: 'online',
-        lastUpdated: firebase.database.ServerValue.TIMESTAMP,
-      };
+      const userStatusPath = `/${ref}/userStatus/${userId}`;
+      const userStatusDatabaseRef = firebase.database().ref(userStatusPath);
       await firebase.database().ref('.info/connected').on('value', (snapshot) => {
         if (snapshot.val() == false) {
           return;
         }
         context.commit('setStarted', true);
-        userStatusDatabaseRef.onDisconnect().set(isOfflineForDatabase).then(() => {
-          userStatusDatabaseRef.set(isOnlineForDatabase);
+        const sessionRef = userStatusDatabaseRef.push();
+        lastSessionPath = `${userStatusPath}/${sessionRef.key}`;
+        sessionRef.child('offline').onDisconnect().set(firebase.database.ServerValue.TIMESTAMP).then(() => {
+          sessionRef.child('online').set(firebase.database.ServerValue.TIMESTAMP);
         });
       });
     },
     stop: async (context) => {
       context.commit('setStarted', false);
+      if (lastSessionPath) {
+        firebase.database().ref(lastSessionPath).child('offline').set(firebase.database.ServerValue.TIMESTAMP);
+      }
       firebase.database().ref('.info/connected').off();
     },
   },

--- a/src/views/QualifyingTests/QualifyingTest/Review.vue
+++ b/src/views/QualifyingTests/QualifyingTest/Review.vue
@@ -109,6 +109,7 @@
 </template>
 
 <script>
+import firebase from '@/firebase';
 import Modal from '@/components/Page/Modal';
 import { QUALIFYING_TEST } from '@/helpers/constants';
 
@@ -134,11 +135,12 @@ export default {
       this.$refs.modalRef.openModal();
     },
     async modalConfirmed(){
-      this.qualifyingTestResponse.status = QUALIFYING_TEST.STATUS.COMPLETED;
-      this.qualifyingTestResponse.statusLog.completed = new Date();
-
-      await this.$store.dispatch('qualifyingTestResponse/save', this.qualifyingTestResponse);
-
+      const data = {
+        status: QUALIFYING_TEST.STATUS.COMPLETED,
+        'statusLog.completed': firebase.firestore.FieldValue.serverTimestamp(),
+      };
+      await this.$store.dispatch('qualifyingTestResponse/save', data);
+      await this.$store.dispatch('connectionMonitor/stop');
       this.$router.push({ name: 'qualifying-test-submitted' });
     },
     modalClosed(){


### PR DESCRIPTION
We are using Realtime Database to build up a log of user presence.

The changes in this PR are to amend the existing PoC solution from a simple 'when was the user last online/offline' to a log of every time the user connection status changes.