### PR TITLE
Add covering letter for suitab-cv-covLtr option

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -52,6 +52,7 @@ import LeadershipSuitability from '@/views/Apply/Assessments/LeadershipSuitabili
 import StatementOfSuitability from '@/views/Apply/Assessments/StatementOfSuitability';
 import StatementOfEligibility from '@/views/Apply/Assessments/StatementOfEligibility';
 import CV from '@/views/Apply/Assessments/CV';
+import CoveringLetter from '@/views/Apply/Assessments/CoveringLetter';
 import Review from '@/views/Apply/FinalCheck/Review';
 import Confirmation from '@/views/Apply/FinalCheck/Confirmation';
 
@@ -473,6 +474,15 @@ const router = new Router({
           meta: {
             requiresAuth: true,
             title: 'Curriculum vitae (CV)',
+          },
+        },
+        {
+          path: 'covering-letter',
+          component: CoveringLetter,
+          name: 'covering-letter',
+          meta: {
+            requiresAuth: true,
+            title: 'Covering Letter',
           },
         },
         {

--- a/src/views/Apply/Assessments/CoveringLetter.vue
+++ b/src/views/Apply/Assessments/CoveringLetter.vue
@@ -1,0 +1,86 @@
+<template>
+  <div class="govuk-grid-row">
+    <form
+      ref="formRef"
+      @submit.prevent="save"
+    >
+      <div class="govuk-grid-column-two-thirds">
+        <BackLink />
+        <h1 class="govuk-heading-xl govuk-!-margin-bottom-0">
+          Covering Letter
+        </h1>
+
+        <span class="govuk-caption-xl govuk-!-margin-bottom-9">
+          Please upload your covering letter
+        </span>
+
+        <ErrorSummary :errors="errors" />
+
+        <FileUpload 
+          id="covering-letter-upload"
+          ref="covering-letter"
+          v-model="application.uploadedCoveringLetter"
+          name="covering-letter"
+          :path="uploadPath"
+          label="Upload Covering letter"
+          required
+        />
+
+        <button
+          :disabled="application.status != 'draft'"
+          class="govuk-button"
+        >
+          Save and continue
+        </button>
+      </div>
+    </form>
+  </div>
+</template>
+
+<script>
+import Form from '@/components/Form/Form';
+import ErrorSummary from '@/components/Form/ErrorSummary';
+import BackLink from '@/components/BackLink';
+import FileUpload from '@/components/Form/FileUpload';
+
+export default {
+  components: {
+    ErrorSummary,
+    BackLink,
+    FileUpload,
+  },
+  extends: Form,
+  data(){
+    const defaults = {
+      uploadedCoveringLetter: null,
+    };
+    const data = this.$store.getters['application/data']();
+    const application = { ...defaults, ...data };
+    return {
+      application: application,
+    };
+  },
+  computed: {
+    userId() {
+      return this.$store.state.auth.currentUser.uid;
+    },
+    vacancy() {
+      return this.$store.state.vacancy.record;
+    },
+    uploadPath() {
+      return `/exercise/${this.vacancy.id}/user/${this.userId}`;
+    },
+  },
+  methods: {
+    async save() {
+      this.validate();
+
+      if (this.isValid()) {
+        this.application.progress.coveringLetter = true;
+        await this.$store.dispatch('application/save', this.application);
+        this.$router.push({ name: 'task-list' });
+      }
+    },
+  },
+};
+</script>

--- a/src/views/Apply/FinalCheck/Review.vue
+++ b/src/views/Apply/FinalCheck/Review.vue
@@ -1804,6 +1804,8 @@ export default {
       case 'statement-of-suitability-with-competencies':
       case 'statement-of-suitability-with-skills-and-abilities':
       case 'statement-of-suitability-with-skills-and-abilities-and-cv':
+      case 'statement-of-suitability-with-skills-and-abilities-and-covering-letter':
+      case 'statement-of-suitability-with-skills-and-abilities-and-cv-and-covering-letter':
         return true;
       default:
         return false;
@@ -1811,7 +1813,10 @@ export default {
     },
     showCoveringLetter() {
       switch (this.vacancy.assessmentOptions) {
+      case 'statement-of-suitability-with-skills-and-abilities-and-covering-letter':
       case 'statement-of-suitability-with-skills-and-abilities-and-cv-and-covering-letter':
+      case 'self-assessment-with-competencies-and-covering-letter':
+      case 'self-assessment-with-competencies-and-cv-and-covering-letter':
         return true;
       default:
         return false;
@@ -1821,6 +1826,7 @@ export default {
       switch (this.vacancy.assessmentOptions) {
       case 'statement-of-suitability-with-skills-and-abilities-and-cv-and-covering-letter':
       case 'self-assessment-with-competencies-and-cv':
+      case 'self-assessment-with-competencies-and-cv-and-covering-letter':
       case 'statement-of-suitability-with-skills-and-abilities-and-cv':
         return true;
       default:
@@ -1839,6 +1845,8 @@ export default {
       switch (this.vacancy.assessmentOptions) {
       case 'self-assessment-with-competencies':
       case 'self-assessment-with-competencies-and-cv':
+      case 'self-assessment-with-competencies-and-covering-letter':
+      case 'self-assessment-with-competencies-and-cv-and-covering-letter':
         return true;
       default:
         return false;
@@ -1861,6 +1869,9 @@ export default {
         if (this.vacancy.jurisdictionQuestion) {
           if (!this.application.progress.jurisdictionPreferences) { isComplete = false; }
         }
+        if (this.vacancy.additionalWorkingPreferences) {
+          if (!this.application.progress.additionalWorkingPreferences) { isComplete = false; }
+        }
         if (this.vacancy.welshRequirement) {
           if (!this.application.progress.welshPosts) { isComplete = false; }
         }
@@ -1873,7 +1884,7 @@ export default {
           if (!this.application.progress.employmentGaps) { isComplete = false; }
         }
         if (this.isNonLegal) {
-          if (this.vacancy.memberships.length) {
+          if (this.vacancy.memberships && this.vacancy.memberships.length) {
             if (this.vacancy.memberships.indexOf('none') === -1) {
               if (!this.application.progress.relevantMemberships) { isComplete = false; }
             }            
@@ -1884,6 +1895,7 @@ export default {
         if (!this.application.progress.reasonableLengthOfService) { isComplete = false; }
         if (this.showStatementOfSuitability && !this.application.progress.statementOfSuitability) { isComplete = false; }
         if (this.showCV && !this.application.progress.cv) { isComplete = false; }
+        if (this.showCoveringLetter && !this.application.progress.coveringLetter) { isComplete = false; }
         if (this.showStatementOfEligibility && !this.application.progress.statementOfEligibility) { isComplete = false; }
         if (this.showSelfAssessment && !this.application.progress.selfAssessmentCompetencies) { isComplete = false; }
       }

--- a/src/views/Apply/FinalCheck/Review.vue
+++ b/src/views/Apply/FinalCheck/Review.vue
@@ -1704,7 +1704,43 @@
               </div>
             </dl>
           </div>
-        </div><!-- END download-as-pdf-div -->
+
+          <div
+            v-if="showCoveringLetter"
+            id="covering-letter-heading"
+            class="govuk-!-margin-top-9"
+          >
+            <h2
+              class="govuk-heading-l"
+              style="display:inline-block;"
+            >
+              Covering Letter
+            </h2>
+            <RouterLink
+              v-if="isDraftApplication"
+              class="govuk-link govuk-body-m change-link"
+              style="display:inline-block;"
+              :to="{name: 'covering-letter'}"
+            >
+              Change
+            </RouterLink>
+
+            <dl class="govuk-summary-list">
+              <div
+                class="govuk-summary-list__row"
+              >
+                <dt class="govuk-summary-list__key">
+                  Uploaded Covering Letter
+                </dt>
+                <dd class="govuk-summary-list__value">
+                  <span v-if="application.uploadedCoveringLetter">Your file has been received</span>
+                  <span v-else>Not yet received</span>
+                </dd>
+              </div>
+            </dl>
+          </div>
+        </div>
+        <!-- END download-as-pdf-div -->
 
         <button
           v-if="isDraftApplication"
@@ -1773,8 +1809,17 @@ export default {
         return false;
       }
     },
+    showCoveringLetter() {
+      switch (this.vacancy.assessmentOptions) {
+      case 'statement-of-suitability-with-skills-and-abilities-and-cv-and-covering-letter':
+        return true;
+      default:
+        return false;
+      }
+    },  
     showCV() {
       switch (this.vacancy.assessmentOptions) {
+      case 'statement-of-suitability-with-skills-and-abilities-and-cv-and-covering-letter':
       case 'self-assessment-with-competencies-and-cv':
       case 'statement-of-suitability-with-skills-and-abilities-and-cv':
         return true;

--- a/src/views/Apply/TaskList.vue
+++ b/src/views/Apply/TaskList.vue
@@ -61,7 +61,6 @@
           </ul>
         </li>
       </ol>
-
       <button
         :disabled="!canApply"
         class="govuk-button"
@@ -191,6 +190,15 @@ export default {
           assessmentOptions.push({ title: 'Self assessment with competencies', id: 'self-assessment-competencies', done: this.applicationProgress.selfAssessmentCompetencies });
           assessmentOptions.push({ title: 'Curriculum vitae (CV)', id: 'cv', done: this.applicationProgress.cv });
           break;
+        case 'self-assessment-with-competencies-and-covering-letter':
+          assessmentOptions.push({ title: 'Self assessment with competencies', id: 'self-assessment-competencies', done: this.applicationProgress.selfAssessmentCompetencies });
+          assessmentOptions.push({ title: 'Covering letter', id: 'covering-letter', done: this.applicationProgress.coveringLetter });
+          break;
+        case 'self-assessment-with-competencies-and-cv-and-covering-letter':
+          assessmentOptions.push({ title: 'Self assessment with competencies', id: 'self-assessment-competencies', done: this.applicationProgress.selfAssessmentCompetencies });
+          assessmentOptions.push({ title: 'Covering letter', id: 'covering-letter', done: this.applicationProgress.coveringLetter });
+          assessmentOptions.push({ title: 'Curriculum vitae (CV)', id: 'cv', done: this.applicationProgress.cv });
+          break;
         case 'statement-of-suitability-with-competencies':
           // @todo what happens to leadership version?
           assessmentOptions.push({ title: 'Statement of suitability', id: 'statement-of-suitability', done: this.applicationProgress.statementOfSuitability });
@@ -203,8 +211,12 @@ export default {
           assessmentOptions.push({ title: 'Statement of suitability', id: 'statement-of-suitability', done: this.applicationProgress.statementOfSuitability });
           assessmentOptions.push({ title: 'Curriculum vitae (CV)', id: 'cv', done: this.applicationProgress.cv });
           break;
+        case 'statement-of-suitability-with-skills-and-abilities-and-covering-letter':
+          assessmentOptions.push({ title: 'Statement of suitability', id: 'statement-of-suitability', done: this.applicationProgress.statementOfSuitability });
+          assessmentOptions.push({ title: 'Covering letter', id: 'covering-letter', done: this.applicationProgress.coveringLetter });
+          break;
         case 'statement-of-suitability-with-skills-and-abilities-and-cv-and-covering-letter':
-          assessmentOptions.push({ title: 'Self assessment with competencies', id: 'self-assessment-competencies', done: this.applicationProgress.selfAssessmentCompetencies });
+          assessmentOptions.push({ title: 'Statement of suitability', id: 'statement-of-suitability', done: this.applicationProgress.statementOfSuitability });
           assessmentOptions.push({ title: 'Curriculum vitae (CV)', id: 'cv', done: this.applicationProgress.cv });
           assessmentOptions.push({ title: 'Covering letter', id: 'covering-letter', done: this.applicationProgress.coveringLetter });
           break;
@@ -230,14 +242,29 @@ export default {
       case 'statement-of-suitability-with-competencies':
       case 'statement-of-suitability-with-skills-and-abilities':
       case 'statement-of-suitability-with-skills-and-abilities-and-cv':
+      case 'statement-of-suitability-with-skills-and-abilities-and-covering-letter':
+      case 'statement-of-suitability-with-skills-and-abilities-and-cv-and-covering-letter':
         return true;
       default:
         return false;
       }
     },
+    showCoveringLetter() {
+      switch (this.vacancy.assessmentOptions) {
+      case 'statement-of-suitability-with-skills-and-abilities-and-covering-letter':
+      case 'statement-of-suitability-with-skills-and-abilities-and-cv-and-covering-letter':
+      case 'self-assessment-with-competencies-and-covering-letter':
+      case 'self-assessment-with-competencies-and-cv-and-covering-letter':
+        return true;
+      default:
+        return false;
+      }
+    },  
     showCV() {
       switch (this.vacancy.assessmentOptions) {
+      case 'statement-of-suitability-with-skills-and-abilities-and-cv-and-covering-letter':
       case 'self-assessment-with-competencies-and-cv':
+      case 'self-assessment-with-competencies-and-cv-and-covering-letter':
       case 'statement-of-suitability-with-skills-and-abilities-and-cv':
         return true;
       default:
@@ -256,6 +283,8 @@ export default {
       switch (this.vacancy.assessmentOptions) {
       case 'self-assessment-with-competencies':
       case 'self-assessment-with-competencies-and-cv':
+      case 'self-assessment-with-competencies-and-covering-letter':
+      case 'self-assessment-with-competencies-and-cv-and-covering-letter':
         return true;
       default:
         return false;
@@ -304,6 +333,7 @@ export default {
         if (!this.application.progress.reasonableLengthOfService) { isComplete = false; }
         if (this.showStatementOfSuitability && !this.application.progress.statementOfSuitability) { isComplete = false; }
         if (this.showCV && !this.application.progress.cv) { isComplete = false; }
+        if (this.showCoveringLetter && !this.application.progress.coveringLetter) { isComplete = false; }
         if (this.showStatementOfEligibility && !this.application.progress.statementOfEligibility) { isComplete = false; }
         if (this.showSelfAssessment && !this.application.progress.selfAssessmentCompetencies) { isComplete = false; }
       }

--- a/src/views/Apply/TaskList.vue
+++ b/src/views/Apply/TaskList.vue
@@ -203,6 +203,11 @@ export default {
           assessmentOptions.push({ title: 'Statement of suitability', id: 'statement-of-suitability', done: this.applicationProgress.statementOfSuitability });
           assessmentOptions.push({ title: 'Curriculum vitae (CV)', id: 'cv', done: this.applicationProgress.cv });
           break;
+        case 'statement-of-suitability-with-skills-and-abilities-and-cv-and-covering-letter':
+          assessmentOptions.push({ title: 'Self assessment with competencies', id: 'self-assessment-competencies', done: this.applicationProgress.selfAssessmentCompetencies });
+          assessmentOptions.push({ title: 'Curriculum vitae (CV)', id: 'cv', done: this.applicationProgress.cv });
+          assessmentOptions.push({ title: 'Covering letter', id: 'covering-letter', done: this.applicationProgress.coveringLetter });
+          break;
         case 'statement-of-eligibility':
           if (this.vacancy.aSCApply && this.vacancy.selectionCriteria && this.vacancy.selectionCriteria.length) {
             assessmentOptions.push({ title: 'Statement of eligibility', id: 'statement-of-eligibility', done: this.applicationProgress.statementOfEligibility });


### PR DESCRIPTION
Understanding the limitations of what can be done here without touching the admin side, ive tried to minimise what ive done in terms of work that will need to be [refactored in admin 843](https://app.zenhub.com/workspaces/platform-development-5ea838cd2aec471eb6d14139/issues/jac-uk/admin/843), this has meant adding a `statement-of-suitability-with-skills-and-abilities-and-cv-and-covering-letter` option for assessments which can be seen on develop env exercise `apply/JHd8HT3QtbY6LupBsu52/`.