### PR TITLE
Avoid redundant navigation on router prototype

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -18,12 +18,14 @@ module.exports = {
   },
   setupFilesAfterEnv: [
     'jest-extended',
+    'jest-canvas-mock',
   ],
   snapshotSerializers: [
     'jest-serializer-vue',
   ],
   testMatch: [
     '**/tests/unit/**/*.spec.(js|jsx|ts|tsx)|**/__tests__/*.(js|jsx|ts|tsx)',
+    '**/tests/journeys/**/*.spec.(js|jsx|ts|tsx)|**/__tests__/*.(js|jsx|ts|tsx)',
   ],
   testURL: 'http://localhost/',
   watchPlugins: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "application-form",
-  "version": "1.21.0",
+  "version": "1.27.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8623,6 +8623,12 @@
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
       "dev": true
     },
+    "cssfontparser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/cssfontparser/-/cssfontparser-1.2.1.tgz",
+      "integrity": "sha1-9AIvyPlwDGgCnVQghK+69CWj8+M=",
+      "dev": true
+    },
     "cssnano": {
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-4.1.10.tgz",
@@ -13430,6 +13436,16 @@
         }
       }
     },
+    "jest-canvas-mock": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/jest-canvas-mock/-/jest-canvas-mock-2.3.0.tgz",
+      "integrity": "sha512-3TMyR66VG2MzAW8Negzec03bbcIjVJMfGNvKzrEnbws1CYKqMNkvIJ8LbkoGYfp42tKqDmhIpQq3v+MNLW2A2w==",
+      "dev": true,
+      "requires": {
+        "cssfontparser": "^1.2.1",
+        "moo-color": "^1.0.2"
+      }
+    },
     "jest-changed-files": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.9.0.tgz",
@@ -15532,6 +15548,23 @@
       "version": "2.26.0",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.26.0.tgz",
       "integrity": "sha512-oIixUO+OamkUkwjhAVE18rAMfRJNsNe/Stid/gwHSOfHrOtw9EhAY2AHvdKZ/k/MggcYELFCJz/Sn2pL8b8JMw=="
+    },
+    "moo-color": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/moo-color/-/moo-color-1.0.2.tgz",
+      "integrity": "sha512-5iXz5n9LWQzx/C2WesGFfpE6RLamzdHwsn3KpfzShwbfIqs7stnoEpaNErf/7+3mbxwZ4s8Foq7I0tPxw7BWHg==",
+      "dev": true,
+      "requires": {
+        "color-name": "^1.1.4"
+      },
+      "dependencies": {
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        }
+      }
     },
     "morgan": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "eslint-plugin-vue": "^5.0.0",
     "firebase-mock": "^2.3.2",
     "firebase-tools": "^8.12.0",
+    "jest-canvas-mock": "^2.3.0",
     "jest-extended": "^0.11.5",
     "sass": "^1.26.10",
     "sass-loader": "^7.3.1",

--- a/src/router.js
+++ b/src/router.js
@@ -1,5 +1,14 @@
 import Vue from 'vue';
 import Router from 'vue-router';
+
+const originalPush = Router.prototype.push;
+
+Router.prototype.push = function push(location) {
+  if (!(this.currentRoute.name === location.name)){
+    return originalPush.call(this, location).catch(err => { throw (err); } );
+  }
+};
+
 import store from '@/store';
 
 import SignIn from '@/views/SignIn';

--- a/src/views/SignIn.vue
+++ b/src/views/SignIn.vue
@@ -105,11 +105,7 @@ export default {
         auth().signInWithEmailAndPassword(this.formData.email, this.formData.password)
           .then((userCredential) => {
             this.$store.dispatch('auth/setCurrentUser', userCredential.user);
-            if (this.$store.getters['vacancy/id']) {
-              this.$router.push({ path: `/apply/${this.$store.getters['vacancy/id']}` });
-            } else {
-              this.$router.push({ name: 'applications' });
-            }
+            this.$router.push({ name: 'applications' });
           })
           .catch((error) => {
             this.errors.push({ id: 'email', message: error.message });

--- a/tests/journeys/page-titles.spec.js
+++ b/tests/journeys/page-titles.spec.js
@@ -1,56 +1,56 @@
-// @FIXME@ *error-four* Quite a different test base, couldnt manage to successfully integrate helpers
-// couldnt tell how to add necessary logic to either 
-// this file or ../helpers.js
-
-import App from '@/App';
-// import Router from 'vue-router';
-// import Vuex from 'vuex';
-import { createTestSubject } from '../unit/helpers';
+import router from '@/router';
+import store from '@/store';
 
 const routes = [
   // ['eligibility-checker', 'Eligibility Checker'],
   // ['eligibility-pass', 'Eligibility Pass'],
   // ['eligibility-fail', 'Eligibility Fail'],
+  ['vacancies', 'Vacancies'],
   ['task-list', 'Apply for a role task list'],
-  ['apply-character-information', 'Declare character information'],
+  ['apply-character-information', 'Character information'],
   ['equality-and-diversity-survey', 'Take the equality and diversity survey'],
   ['pre-application-judicial-education', 'Pre-application judicial education'],
-  ['apply-personal-details', 'Add personal details'],
+  ['apply-personal-details', 'Personal details'],
   ['assessors-details', 'Give independent assessors details'],
-  ['self-assessment-competencies', 'Upload self-assessment competencies'],
+  ['self-assessment-competencies', 'Self-assessment competencies'],
   ['review', 'Review application'],
-  ['judicial-experience', 'Add judicial experience'],
-  ['post-qualification-work-experience', 'Add post-qualification work experience'],
-  ['relevant-qualifications', 'Add relevant qualifications'],
-  ['part-time-working-preferences', 'Set part-time working preferences'],
+  ['judicial-experience', 'Judicial experience'],
+  ['post-qualification-work-experience', 'Post-qualification work experience'],
+  ['relevant-qualifications', 'Relevant qualifications'],
+  ['part-time-working-preferences', 'Part-time working preferences'],
   ['leadership-statement-of-suitability', 'Statement of suitability'],
   ['statement-of-suitability', 'Statement of suitability'],
   ['confirmation', 'Confirmation'],
 ];
 
-xdescribe('Page titles', () => {
-  let wrapper;
-  beforeEach(() => {
-    // const localVue = createLocalVue();
-    // localVue.use(Router);
-    // localVue.use(Vuex);
+describe('Page titles', () => {
 
-    // router = require('@/router').default;
-    // store = require('@/store').default;
-    window.scrollTo = () => {};
-    wrapper = createTestSubject(App, {
-      stubs: ['RouterView'],
-    });
-  });
-
+  const pushSpy = jest.spyOn(router, 'push');
   const user = {
     uid: 'abc123',
     email: 'user@judicialappointments.digital',
   };
+  
+  describe('router', () => {
+    beforeEach(() => {
+      router.push({ name: 'sign-in' });
+      store.dispatch('auth/setCurrentUser', user);
+      pushSpy.mockClear();
+    });
+    
+    it('wont push to same route', () => {
+      router.push({ name: 'vacancies' });
+      expect(document.title).toContain('Vacancies');
+      expect(pushSpy).toHaveBeenCalledTimes(1);
+      router.push({ name: 'vacancies' });
+      expect(document.title).toContain('Vacancies');
+    });    
+
+  });
 
   describe('sign in', () => {
     beforeEach(() => {
-      wrapper.vm.$router.push({ name: 'sign-in' });
+      router.push({ name: 'sign-in' });
     });
 
     it('contains Sign In', () => {
@@ -64,14 +64,14 @@ xdescribe('Page titles', () => {
 
   describe.each(routes)('%s', (routeName, routeTitle) => {
     beforeEach(() => {
-      wrapper.vm.$store.dispatch('auth/setCurrentUser', user);
-      wrapper.vm.$router.push({ name: routeName, params: { id: 123 } });
+      store.dispatch('auth/setCurrentUser', user);
+      router.push({ name: routeName, params: { id: 123 } });
     });
 
     it(`contains ${routeTitle}`, () => {
       expect(document.title).toContain(routeTitle);
     });
-
+    
     it('contains Judicial Appointments Commission', () => {
       expect(document.title).toContain('Judicial Appointments Commission');
     });


### PR DESCRIPTION
This is PR is one way we could handle the redundant navigation errors cropping up across apply. 

**PROS**: 
We wont have to add a unique catch to each instance of `push` within our app.
Any other errors from a `push` call within our app will still be caught any logged on sentry, might will hopefully provide some more details for an error.

**CONS**: It's worth challenging how robust of a solution this is, as i'm conscious this catch-all approach could potentially cause an issue if route names aren't strictly unique, perhaps when navigating between child routes(?)

