### PR TITLE
#592 Include Session with server time offset

### DIFF
--- a/src/components/QualifyingTest/Countdown2.vue
+++ b/src/components/QualifyingTest/Countdown2.vue
@@ -129,7 +129,6 @@ export default {
     this.start = start.getTime();
     this.end = end.getTime();
 
-    console.log('call first tick', this.serverTimeOffset);
     this.tick(this.start, this.end);
 
     this.interval = setInterval(() => {

--- a/src/components/QualifyingTest/Countdown2.vue
+++ b/src/components/QualifyingTest/Countdown2.vue
@@ -20,8 +20,8 @@
           <span style="margin-right: 5px;">
             {{ mobileView ? '' : 'Time Remaining:' }}
           </span>
-          <span 
-            v-if="hours" 
+          <span
+            v-if="hours"
           >
             {{ hours | zeroPad }}:
           </span>
@@ -73,6 +73,10 @@ export default {
       type: Date,
       default: null,
     },
+    serverTimeOffset: {
+      type: Number,
+      default: 0,
+    },
     mobileView: {
       type: Boolean,
       default: false,
@@ -103,7 +107,7 @@ export default {
       seconds: '',
       bckClass: '',
       saveCounter: 0,
-      saveSeconds: 5, 
+      saveSeconds: 5,
     };
   },
   mounted() {
@@ -115,7 +119,7 @@ export default {
     if (this.endTime !== null) {
       const absoluteEnd = new Date(this.endTime);
       const isAbsoluteEndBeforetheEnd = absoluteEnd < end;
-    
+
       if (isAbsoluteEndBeforetheEnd) {
         end = absoluteEnd;
       }
@@ -125,6 +129,7 @@ export default {
     this.start = start.getTime();
     this.end = end.getTime();
 
+    console.log('call first tick', this.serverTimeOffset);
     this.tick(this.start, this.end);
 
     this.interval = setInterval(() => {
@@ -133,7 +138,7 @@ export default {
     }, second);
   },
   methods: {
-    isMobile() {
+    isMobile() {  // @TODO this should be done via CSS instead of JS
       if (/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)) {
         return true;
       } else {
@@ -141,7 +146,7 @@ export default {
       }
     },
     tick(start, end) {
-      const now = new Date().getTime();
+      const now = new Date().getTime() + this.serverTimeOffset;
 
       const timeRemaining = end - now;
 

--- a/src/main.js
+++ b/src/main.js
@@ -34,6 +34,7 @@ auth().onAuthStateChanged( (user) => {
   store.dispatch('auth/setCurrentUser', user);
   if (store.getters['auth/isSignedIn']) {
     if (store.getters['vacancy/id']) {
+      // TODO check that we're not already on this page!
       router.push(`/apply/${store.getters['vacancy/id']}`);
     } else {
       // router.push('applications');

--- a/src/store.js
+++ b/src/store.js
@@ -14,6 +14,7 @@ import application from '@/store/application';
 import qualifyingTestResponse from '@/store/qualifyingTestResponse';
 import qualifyingTestResponses from '@/store/qualifyingTestResponses';
 import connectionMonitor from '@/store/connectionMonitor';
+import session from '@/store/session';
 
 const store = new Vuex.Store({
   // Don't use strict mode in production for performance reasons (https://vuex.vuejs.org/guide/strict.html)
@@ -29,6 +30,7 @@ const store = new Vuex.Store({
     qualifyingTestResponse,
     qualifyingTestResponses,
     connectionMonitor,
+    session,
   },
   state: {},
   mutations: {

--- a/src/store/connectionMonitor.js
+++ b/src/store/connectionMonitor.js
@@ -40,7 +40,7 @@ export default {
     setStarted(state, started) {
       state.started = started;
     },
-  },  
+  },
   state: {
     started: false,
   },

--- a/src/store/session.js
+++ b/src/store/session.js
@@ -1,0 +1,31 @@
+/**
+ * Here we use Realtime Database to get server time offset
+ */
+import firebase from '@firebase/app';
+import 'firebase/database';
+
+const module = {
+  namespaced: true,
+  actions: {
+    async load(context) {
+      // We are calling both `once` and `on` here so that we wait for offset and respond to changes
+      // TODO changing computer time does not get picked up by this...even if we call `.off()`. Possibly need to do a write first?
+      const ref = firebase.database().ref('.info/serverTimeOffset');
+      const snapshot = await ref.once('value');
+      context.commit('setServerTimeOffset', snapshot.val());
+      ref.on('value', (snapshot) => {
+        context.commit('setServerTimeOffset', snapshot.val());
+      });
+    },
+  },
+  mutations: {
+    setServerTimeOffset(state, offset) {
+      state.serverTimeOffset = offset;
+    },
+  },
+  state: {
+    serverTimeOffset: 0,
+  },
+};
+
+export default module;

--- a/src/views/QualifyingTests/QualifyingTest.vue
+++ b/src/views/QualifyingTests/QualifyingTest.vue
@@ -13,6 +13,7 @@
         :start-time="qualifyingTestResponse.statusLog.started"
         :end-time="qualifyingTestResponse.qualifyingTest.endDate"
         :duration="qualifyingTestResponse.duration.testDurationAdjusted"
+        :server-time-offset="serverTimeOffset"
         :warning="5"
         :alert="1"
         :mobile-view="isMobile"
@@ -123,12 +124,15 @@ export default {
     isInformationPage() {
       return this.$route.name === 'qualifying-test-information';
     },
+    serverTimeOffset() {
+      return this.$store.state.session.serverTimeOffset;
+    },
   },
   watch: {
-    qualifyingTestResponse: function (newVal) {
+    qualifyingTestResponse: async function (newVal) {
       if (newVal) {
         if (this.testInProgress) {
-          this.$store.dispatch('connectionMonitor/start', `qualifyingTest/${this.qualifyingTestId}`);
+          await this.$store.dispatch('connectionMonitor/start', `qualifyingTest/${this.qualifyingTestId}`);
         } else {
           this.$store.dispatch('connectionMonitor/stop');
         }
@@ -137,6 +141,14 @@ export default {
     '$route.params.qualifyingTestId'() {
       this.loadQualifyingTestResponse();
     },
+    autoSave: function (newVal, oldVal) {
+      if (newVal !== oldVal) {
+        if (this.autoSave) { // here we use autoSave event to refresh session.serverTimeOffset
+          this.$store.dispatch('session/load');
+        }
+      }
+    },
+
   },
   async mounted() {
     await this.loadQualifyingTestResponse();


### PR DESCRIPTION
Using server time offset means our countdown timer is based off of server time (pretty accurately) so client time being 'out' should not effect the duration the candidate has to complete a QT.

Have included as a session variable for every user as `serverTimeOffset` will be useful in other places - e.g. when vacancies open & close; listing QTs etc.

NOTE: this does not yet update if a user adjusts their clock during a QT. Handling this will be covered in another ticket.

---

To test:

1. try adjusting local time, refreshing browser then starting a test. The remaining duration on the countdown should be accurate.
2. Start a test. Adjust local time. Notice that duration remaining changes. Refresh page. The remaining duration should be accurate.

To be covered later:
3. Start a test. Adjust local time. Do not refresh. The remaining duration should be accurate.