### PR TITLE
#556 Router issue: Error: Avoided redundant navigation

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -38,7 +38,7 @@ auth().onAuthStateChanged( (user) => {
   if (store.getters['auth/isSignedIn']) {
     if (store.getters['vacancy/id']) {
       // TODO check that we're not already on this page!
-      router.push(`/apply/${store.getters['vacancy/id']}`);
+      router.push({ name: 'apply', params: { id: `${this.$store.getters['vacancy/id']}` } });
     } else {
       // router.push('applications');
     }

--- a/src/router.js
+++ b/src/router.js
@@ -251,6 +251,7 @@ const router = new Router({
     {
       path: '/apply/:id',
       component: Apply,
+      name: 'apply',
       children: [
         {
           path: '',

--- a/src/views/SignIn.vue
+++ b/src/views/SignIn.vue
@@ -119,7 +119,7 @@ export default {
 
             this.$store.dispatch('auth/setCurrentUser', userCredential.user);
             if (this.$store.getters['vacancy/id']) {
-              this.$router.push({ path: `/apply/${this.$store.getters['vacancy/id']}` });
+              this.$router.push({ name: 'apply', params: { id: `${this.$store.getters['vacancy/id']}` } });
             } else {
               this.$router.push({ name: 'applications' });
             }

--- a/src/views/SignUp.vue
+++ b/src/views/SignUp.vue
@@ -141,7 +141,7 @@ export default {
 
         if (candidate) {
           if (this.$store.getters['vacancy/id']) {
-            this.$router.push({ path: `/apply/${this.$store.getters['vacancy/id']}` });
+            this.$router.push({ name: 'apply', params: { id: `${this.$store.getters['vacancy/id']}` } });
           } else {
             this.$router.push({ name: 'applications' });
           }

--- a/tests/unit/views/SignUp.spec.js
+++ b/tests/unit/views/SignUp.spec.js
@@ -149,7 +149,7 @@ describe('views/SignUp', () => {
 
         await wrapper.vm.signUp();
 
-        expect(wrapper.vm.$router.push).toHaveBeenCalledWith( { name: 'apply', params: { id:  mockVacancyId } });
+        expect(wrapper.vm.$router.push).toHaveBeenCalledWith( { name: 'apply', params: { id: mockVacancyId } });
       });
     });
 

--- a/tests/unit/views/SignUp.spec.js
+++ b/tests/unit/views/SignUp.spec.js
@@ -149,9 +149,8 @@ describe('views/SignUp', () => {
 
         await wrapper.vm.signUp();
 
-        expect(wrapper.vm.$router.push).toHaveBeenCalledWith({ path: `/apply/${mockVacancyId}` });
+        expect(wrapper.vm.$router.push).toHaveBeenCalledWith( { name: 'apply', params: { id:  mockVacancyId } });
       });
-
     });
 
     describe('createCandidate()', () => {


### PR DESCRIPTION
the solution for this issue relies on the fact that we were using route.push(path) instead of the different processing way of doing it route.push({'name': routeName, params: routeParams})