### PR TITLE
Split by non-alphabetic characters

### DIFF
--- a/src/components/Form/FormField.vue
+++ b/src/components/Form/FormField.vue
@@ -131,8 +131,7 @@ export default {
 
         if (this.wordLimit && this.value) {
           const words = this.value
-            .replace(/-/g, '')
-            .split(/\s+/)
+            .split(/[^a-z]/i)
             .filter(item => item !== '');
           if (words.length > this.wordLimit) {
             this.setError(`You have reached the limit of ${this.wordLimit} words`);

--- a/src/components/Form/TextareaInput.vue
+++ b/src/components/Form/TextareaInput.vue
@@ -67,8 +67,7 @@ export default {
       const value = this.value;
       const result = value ? value : '';
       return result
-        .replace(/-/g, '')
-        .split(/\s+/)
+        .split(/[^a-z]/i)
         .filter(item => item !== '');
     },
     text: {


### PR DESCRIPTION
An Addendum to the work on word limiting the ASC, we now split the string with all non-alphabetic characters as delimiters.
meaning 
`how.many3words!is_This?`
now registers as 5 words, not 1