### PR TITLE
admin#1212 Include Leadership Judge details form

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -43,6 +43,7 @@ import EqualityAndDiversitySurvey from '@/views/Apply/AccountProfile/EqualityAnd
 import PAJE from '@/views/Apply/AccountProfile/PAJE';
 import ApplyPersonalDetails from '@/views/Apply/AccountProfile/PersonalDetails';
 import AssessorsDetails from '@/views/Apply/Assessments/AssessorsDetails';
+import LeadershipJudgeDetails from '@/views/Apply/Assessments/LeadershipJudgeDetails';
 import SelfAssessmentCompetencies from '@/views/Apply/Assessments/SelfAssessmentCompetencies';
 import JudicialExperience from '@/views/Apply/QualificationsAndExperience/JudicialExperience';
 import PostQualificationWorkExperience from '@/views/Apply/QualificationsAndExperience/PostQualificationWorkExperience';
@@ -396,6 +397,15 @@ const router = new Router({
           meta: {
             requiresAuth: true,
             title: 'Give independent assessors details',
+          },
+        },
+        {
+          path: 'leadership-judge-details',
+          component: LeadershipJudgeDetails,
+          name: 'leadership-judge-details',
+          meta: {
+            requiresAuth: true,
+            title: 'Give Leadership Judge details',
           },
         },
         {

--- a/src/views/Apply/Assessments/LeadershipJudgeDetails.vue
+++ b/src/views/Apply/Assessments/LeadershipJudgeDetails.vue
@@ -1,0 +1,120 @@
+<template>
+  <div class="govuk-grid-row">
+    <form
+      ref="formRef"
+      @submit.prevent="save"
+    >
+      <div class="govuk-grid-column-two-thirds">
+        <BackLink />
+        <h1 class="govuk-heading-xl">
+          Leadership Judge details
+        </h1>
+
+        <ErrorSummary :errors="errors" />
+
+        <p class="govuk-body-l">
+          Please read the
+          <RouterLink
+            class="govuk-link"
+            :to="{ name: 'vacancy-details', params: { id: vacancyId } }"
+            target="_blank"
+          >
+            <span>Information Page</span>
+          </RouterLink>
+          for this exercise before completing this section. The Leadership Judge statement of suitability will contribute to your overall assessment alongside the evidence you have provided in your statement of suitability and written work. It should provide evidence that you can demonstrate the skills relevant to the Skills and Abilities for this role. No other references are sought for section 9(1) authorisation, only a statement of suitability from your Leadership Judge.<br>
+          <br>
+          Do not nominate the Lead Judge, the Master of the Rolls, a Head of Division, the Statutory Consultees or the Appropriate Authorities whose names can be found in the
+          <RouterLink
+            class="govuk-link"
+            :to="{ name: 'vacancy-details', params: { id: vacancyId } }"
+            target="_blank"
+          >
+            <span>Information Page</span>
+          </RouterLink>
+          for this exercise.
+        </p>
+
+        <TextField
+          id="full-name"
+          v-model="application.leadershipJudgeDetails.fullName"
+          label="Full name"
+          required
+        />
+        <TextField
+          id="title"
+          v-model="application.leadershipJudgeDetails.title"
+          label="Title or position"
+          required
+        />
+        <TextField
+          id="email"
+          v-model="application.leadershipJudgeDetails.email"
+          label="Email"
+          type="email"
+          required
+        />
+        <TextField
+          id="phone"
+          v-model="application.leadershipJudgeDetails.phone"
+          label="Phone"
+          type="tel"
+          required
+        />
+
+        <button
+          :disabled="application.status != 'draft'"
+          class="govuk-button info-btn--assessor-details--save-and-continue"
+        >
+          Save and continue
+        </button>
+      </div>
+    </form>
+  </div>
+</template>
+
+<script>
+import Form from '@/components/Form/Form';
+import ErrorSummary from '@/components/Form/ErrorSummary';
+import TextField from '@/components/Form/TextField';
+import BackLink from '@/components/BackLink';
+
+export default {
+  components: {
+    ErrorSummary,
+    TextField,
+    BackLink,
+  },
+  extends: Form,
+  data(){
+    const defaults = {
+      leadershipJudgeDetails: {
+        email: null,
+        fullName: null,
+        phone: null,
+        title: null,
+      },
+    };
+    const data = this.$store.getters['application/data']();
+    const application = { ...defaults, ...data };
+    return {
+      application: application,
+    };
+
+  },
+  computed: {
+    vacancyId() {
+      return this.$route.params.id;
+    },
+  },
+  methods: {
+    async save() {
+      this.validate();
+      if (this.isValid()) {
+        this.application.progress.leadershipJudgeDetails = true;
+        await this.$store.dispatch('application/save', this.application);
+        this.$router.push({ name: 'task-list' });
+      }
+    },
+  },
+};
+</script>

--- a/src/views/Apply/FinalCheck/Review.vue
+++ b/src/views/Apply/FinalCheck/Review.vue
@@ -1471,80 +1471,140 @@
             </div>
           </dl>
 
-          <div class="govuk-!-margin-top-9">
-            <h2
-              class="govuk-heading-l"
-              style="display:inline-block;"
-            >
-              Independent assessors
-            </h2>
-            <RouterLink
-              v-if="isDraftApplication && canEdit"
-              class="govuk-link govuk-body-m change-link"
-              style="display:inline-block;"
-              :to="{name: 'assessors-details'}"
-            >
-              Change
-            </RouterLink>
+          <div v-if="showAssessorsDetails">
+            <div class="govuk-!-margin-top-9">
+              <h2
+                class="govuk-heading-l"
+                style="display:inline-block;"
+              >
+                Independent assessors
+              </h2>
+              <RouterLink
+                v-if="isDraftApplication && canEdit"
+                class="govuk-link govuk-body-m change-link"
+                style="display:inline-block;"
+                :to="{name: 'assessors-details'}"
+              >
+                Change
+              </RouterLink>
+            </div>
+            <dl class="govuk-summary-list">
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                  Full name
+                </dt>
+                <dd class="govuk-summary-list__value">
+                  {{ application.firstAssessorFullName }}
+                </dd>
+              </div>
+
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                  Title or position
+                </dt>
+                <dd class="govuk-summary-list__value">
+                  {{ application.firstAssessorTitle }}
+                </dd>
+              </div>
+
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                  Email
+                </dt>
+                <dd class="govuk-summary-list__value">
+                  {{ application.firstAssessorEmail }}
+                </dd>
+              </div>
+
+              <hr class="govuk-section-break govuk-section-break--xl">
+
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                  Full name
+                </dt>
+                <dd class="govuk-summary-list__value">
+                  {{ application.secondAssessorFullName }}
+                </dd>
+              </div>
+
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                  Title or position
+                </dt>
+                <dd class="govuk-summary-list__value">
+                  {{ application.secondAssessorTitle }}
+                </dd>
+              </div>
+
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                  Email
+                </dt>
+                <dd class="govuk-summary-list__value">
+                  {{ application.secondAssessorEmail }}
+                </dd>
+              </div>
+            </dl>
           </div>
 
-          <dl class="govuk-summary-list">
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                Full name
-              </dt>
-              <dd class="govuk-summary-list__value">
-                {{ application.firstAssessorFullName }}
-              </dd>
+          <div v-if="showLeadershipJudgeDetails">
+            <div class="govuk-!-margin-top-9">
+              <h2
+                class="govuk-heading-l"
+                style="display:inline-block;"
+              >
+                Leadership Judge details
+              </h2>
+              <RouterLink
+                v-if="isDraftApplication && canEdit"
+                class="govuk-link govuk-body-m change-link"
+                style="display:inline-block;"
+                :to="{name: 'leadership-judge-details'}"
+              >
+                Change
+              </RouterLink>
             </div>
+            <dl
+              v-if="application.leadershipJudgeDetails"
+              class="govuk-summary-list"
+            >
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                  Full name
+                </dt>
+                <dd class="govuk-summary-list__value">
+                  {{ application.leadershipJudgeDetails.fullName }}
+                </dd>
+              </div>
 
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                Title or position
-              </dt>
-              <dd class="govuk-summary-list__value">
-                {{ application.firstAssessorTitle }}
-              </dd>
-            </div>
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                  Title or position
+                </dt>
+                <dd class="govuk-summary-list__value">
+                  {{ application.leadershipJudgeDetails.title }}
+                </dd>
+              </div>
 
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                Email
-              </dt>
-              <dd class="govuk-summary-list__value">
-                {{ application.firstAssessorEmail }}
-              </dd>
-            </div>
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                  Email
+                </dt>
+                <dd class="govuk-summary-list__value">
+                  {{ application.leadershipJudgeDetails.email }}
+                </dd>
+              </div>
 
-            <hr class="govuk-section-break govuk-section-break--xl">
-
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                Full name
-              </dt>
-              <dd class="govuk-summary-list__value">
-                {{ application.secondAssessorFullName }}
-              </dd>
-            </div>
-
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                Title or position
-              </dt>
-              <dd class="govuk-summary-list__value">
-                {{ application.secondAssessorTitle }}
-              </dd>
-            </div>
-
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                Email
-              </dt>
-              <dd class="govuk-summary-list__value">
-                {{ application.secondAssessorEmail }}
-              </dd>
-            </div>
-          </dl>
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                  Telephone
+                </dt>
+                <dd class="govuk-summary-list__value">
+                  {{ application.leadershipJudgeDetails.phone }}
+                </dd>
+              </div>
+            </dl>
+          </div>
 
           <div v-if="application.additionalInfo">
             <div
@@ -1840,6 +1900,14 @@ export default {
     showMemberships() {
       return this.vacancy.memberships && this.vacancy.memberships.indexOf('none') === -1;
     },
+    // @todo the following are also used in TaskList.vue. Look to share them.
+    showAssessorsDetails() {
+      // show IAs unless it has been turned off
+      return !(this.vacancy.assessmentMethods && this.vacancy.assessmentMethods.independentAssessments === false);
+    },
+    showLeadershipJudgeDetails() {
+      return this.vacancy.assessmentMethods && this.vacancy.assessmentMethods.leadershipJudgeAssessment;
+    },
     showStatementOfSuitability() {
       switch (this.vacancy.assessmentOptions) {
       case 'statement-of-suitability-with-competencies':
@@ -1900,7 +1968,6 @@ export default {
         if (!this.application.progress.personalDetails) { isComplete = false; }
         if (!this.application.progress.characterInformation) { isComplete = false; }
         if (!this.application.progress.equalityAndDiversitySurvey) { isComplete = false; }
-        if (!this.application.progress.assessorsDetails) { isComplete = false; }
         if (this.vacancy.isSPTWOffered) {
           if (!this.application.progress.partTimeWorkingPreferences) { isComplete = false; }
         }
@@ -1934,11 +2001,15 @@ export default {
           if (!this.application.progress.employmentGaps) { isComplete = false; }
         }
         if (!this.application.progress.reasonableLengthOfService) { isComplete = false; }
+
+        if (this.showAssessorsDetails && !this.application.progress.assessorsDetails) { isComplete = false; }
+        if (this.showLeadershipJudgeDetails && !this.application.progress.leadershipJudgeDetails) { isComplete = false; }
         if (this.showStatementOfSuitability && !this.application.progress.statementOfSuitability) { isComplete = false; }
         if (this.showCV && !this.application.progress.cv) { isComplete = false; }
         if (this.showCoveringLetter && !this.application.progress.coveringLetter) { isComplete = false; }
         if (this.showStatementOfEligibility && !this.application.progress.statementOfEligibility) { isComplete = false; }
         if (this.showSelfAssessment && !this.application.progress.selfAssessmentCompetencies) { isComplete = false; }
+        if (!this.application.progress.additionalInfo) { isComplete = false; }
       }
       return isComplete;
     },
@@ -1971,17 +2042,8 @@ export default {
     },
   },
   mounted() {
-
-    // console.log(this.vacancy.schedule2Apply);
-    // console.log(this.vacancy.appliedSchedule);
-    // console.log(this.application.applyingUnderSchedule2Three);
-    // console.log(this.application);
-    // console.log(this.application.applyingUnderSchedule2Three);
-    // console.log(this.application.experienceUnderSchedule2Three);
-
     this.canApply = this.checkIfCanApply();
     this.canEdit = this.checkIfCanEdit();
-
     if (this.$store.getters['vacancy/isOpen']()) {
       const self = this;
       setInterval(() => {

--- a/src/views/Apply/TaskList.vue
+++ b/src/views/Apply/TaskList.vue
@@ -242,7 +242,13 @@ export default {
           }
         }
 
-        const assessmentOptions = [{ title: 'Independent assessors\' details', id: 'assessors-details', done: this.applicationProgress.assessorsDetails }];
+        const assessmentOptions = [];
+        if (this.showAssessorsDetails) {
+          assessmentOptions.push({ title: 'Independent assessors\' details', id: 'assessors-details', done: this.applicationProgress.assessorsDetails });
+        }
+        if (this.showLeadershipJudgeDetails) {
+          assessmentOptions.push({ title: 'Leadership Judge details', id: 'leadership-judge-details', done: this.applicationProgress.leadershipJudgeDetails });
+        }
         switch (this.vacancy.assessmentOptions) {
         case 'self-assessment-with-competencies':
           assessmentOptions.push({ title: 'Self assessment with competencies', id: 'self-assessment-competencies', done: this.applicationProgress.selfAssessmentCompetencies });
@@ -307,6 +313,13 @@ export default {
       return data;
     },
     // @todo the following are copied from Review.vue. Look to share them. Maybe use vuex.
+    showAssessorsDetails() {
+      // show IAs unless it has been turned off
+      return !(this.vacancy.assessmentMethods && this.vacancy.assessmentMethods.independentAssessments === false);
+    },
+    showLeadershipJudgeDetails() {
+      return this.vacancy.assessmentMethods && this.vacancy.assessmentMethods.leadershipJudgeAssessment;
+    },
     showStatementOfSuitability() {
       switch (this.vacancy.assessmentOptions) {
       case 'statement-of-suitability-with-competencies':
@@ -367,7 +380,6 @@ export default {
         if (!this.application.progress.personalDetails) { isComplete = false; }
         if (!this.application.progress.characterInformation) { isComplete = false; }
         if (!this.application.progress.equalityAndDiversitySurvey) { isComplete = false; }
-        if (!this.application.progress.assessorsDetails) { isComplete = false; }
         if (this.vacancy.isSPTWOffered) {
           if (!this.application.progress.partTimeWorkingPreferences) { isComplete = false; }
         }
@@ -401,6 +413,9 @@ export default {
           if (!this.application.progress.employmentGaps) { isComplete = false; }
         }
         if (!this.application.progress.reasonableLengthOfService) { isComplete = false; }
+
+        if (this.showAssessorsDetails && !this.application.progress.assessorsDetails) { isComplete = false; }
+        if (this.showLeadershipJudgeDetails && !this.application.progress.leadershipJudgeDetails) { isComplete = false; }
         if (this.showStatementOfSuitability && !this.application.progress.statementOfSuitability) { isComplete = false; }
         if (this.showCV && !this.application.progress.cv) { isComplete = false; }
         if (this.showCoveringLetter && !this.application.progress.coveringLetter) { isComplete = false; }


### PR DESCRIPTION
Includes the Leadership Judge details form for vacancies that have been appropriately configured (see [admin#1212](/jac-uk/admin/1212))

Also excludes the Independent Assessors form where the vacancy has been configured to not have it as an assessment method (otherwise IAs will always be requested).

**To test**
The following changes have been implemented
- Task list. Exclude 'Independent Assessments' if it has been turned off
- Task list. Include 'Leadership Judge details' if relevant
- Task list. Review button. Update logic so Leadership Judge details are required to enable the button (if relevant)
- Leadership Judge details. New form to add/edit Leadership Judge details
- Review. Exclude 'Independent Assessments' if it has been turned off
- Review. Include 'Leadership Judge details' if relevant
- Review. Send application button. Update logic so Leadership Judge details are required to enable the button (if relevant)