### PR TITLE
Enabled jac-kit in Apply

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,9 @@ jobs:
       - checkout
       - run:
           name: 'Setup'
-          command: npm ci
+          command: |
+            echo "//npm.pkg.github.com/:_authToken=${GITHUB_PACKAGES_TOKEN}" > ~/.npmrc
+            npm ci
       - persist_to_workspace:
           root: .
           paths:
@@ -117,6 +119,6 @@ workflows:
             - test
           filters:
             branches:
-              only: 
+              only:
                 - master
                 - /hotfix/.*/

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://npm.pkg.github.com/jac-uk

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "application-form",
-  "version": "1.35.0",
+  "version": "1.36.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2453,6 +2453,11 @@
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.2.tgz",
       "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
       "dev": true
+    },
+    "@jac-uk/jac-kit": {
+      "version": "0.0.31",
+      "resolved": "https://npm.pkg.github.com/download/@jac-uk/jac-kit/0.0.31/a1de9bb5586fcedb7948ffeb073c5957ebfc6a46d5b25268f4e4a4e01b457150",
+      "integrity": "sha512-0SmaVOB6SEhHOUDJBs5ZZlharnadJgdz4wBq81Nqph2wpQddVblUmskOasKFi3nPF5cG+uugwdXay5oZHn1xZA=="
     },
     "@jest/console": {
       "version": "24.9.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test-ci": "TZ='Europe/London' vue-cli-service test:unit --ci --runInBand"
   },
   "dependencies": {
+    "@jac-uk/jac-kit": "latest",
     "@ministryofjustice/frontend": "0.0.19-alpha",
     "@sentry/browser": "^5.20.1",
     "@sentry/integrations": "^5.20.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test-ci": "TZ='Europe/London' vue-cli-service test:unit --ci --runInBand"
   },
   "dependencies": {
-    "@jac-uk/jac-kit": "latest",
+    "@jac-uk/jac-kit": "0.0.31",
     "@ministryofjustice/frontend": "0.0.19-alpha",
     "@sentry/browser": "^5.20.1",
     "@sentry/integrations": "^5.20.1",


### PR DESCRIPTION
So, I've tried to add jac-kit into Apply. I've:

- created .npmrc file
- made changes in config.yml (referring to the same file in Admin repo).
- run `npm install @jac-uk/jac-kit@0.0.31` and updated package.json dependency to `"@jac-uk/jac-kit": "latest"` (the same as in Admin)
- restarted the project by running `npm run serve`