### PR TITLE
Remove name-blind sift and phone assessment from timeline

### DIFF
--- a/src/helpers/Timeline/exerciseTimeline.js
+++ b/src/helpers/Timeline/exerciseTimeline.js
@@ -79,28 +79,6 @@ const exerciseTimeline = (data) => {
   }
 
   if (data.shortlistingMethods && data.shortlistingMethods.length > 0) {
-    // timeline.push(
-    //   {
-    //     entry: 'Shortlisting',
-    //   },
-    // );
-
-    // if(data.shortlistingMethods.includes('paper-sift')) {
-    //   timeline.push(
-    //     createShortlistingMethod('Sift', data.siftStartDate, data.siftEndDate)
-    //   );
-    // }
-    // 
-    // if (data.shortlistingMethods.includes('name-blind-paper-sift')) {
-    //   timeline.push(
-    //     createShortlistingMethod('Name-blind sift', data.nameBlindSiftStartDate, data.nameBlindSiftEndDate)
-    //   );
-    // }
-    // 
-    // if (data.shortlistingMethods.includes('telephone-assessment')) {
-    //   timeline.push(createShortlistingMethod('Telephone assessment', data.telephoneAssessmentStartDate, data.telephoneAssessmentEndDate));
-    // }
-
     if (data.shortlistingMethods.includes('situational-judgement-qualifying-test')) {
       if (data.situationalJudgementTestDate) {
         timeline.push(

--- a/src/helpers/Timeline/exerciseTimeline.js
+++ b/src/helpers/Timeline/exerciseTimeline.js
@@ -90,16 +90,16 @@ const exerciseTimeline = (data) => {
     //     createShortlistingMethod('Sift', data.siftStartDate, data.siftEndDate)
     //   );
     // }
-
-    if (data.shortlistingMethods.includes('name-blind-paper-sift')) {
-      timeline.push(
-        createShortlistingMethod('Name-blind sift', data.nameBlindSiftStartDate, data.nameBlindSiftEndDate)
-      );
-    }
-
-    if (data.shortlistingMethods.includes('telephone-assessment')) {
-      timeline.push(createShortlistingMethod('Telephone assessment', data.telephoneAssessmentStartDate, data.telephoneAssessmentEndDate));
-    }
+    // 
+    // if (data.shortlistingMethods.includes('name-blind-paper-sift')) {
+    //   timeline.push(
+    //     createShortlistingMethod('Name-blind sift', data.nameBlindSiftStartDate, data.nameBlindSiftEndDate)
+    //   );
+    // }
+    // 
+    // if (data.shortlistingMethods.includes('telephone-assessment')) {
+    //   timeline.push(createShortlistingMethod('Telephone assessment', data.telephoneAssessmentStartDate, data.telephoneAssessmentEndDate));
+    // }
 
     if (data.shortlistingMethods.includes('situational-judgement-qualifying-test')) {
       if (data.situationalJudgementTestDate) {

--- a/tests/unit/helpers/Timeline/exerciseTimeline.spec.js
+++ b/tests/unit/helpers/Timeline/exerciseTimeline.spec.js
@@ -31,28 +31,6 @@ describe('helpers/Form/exerciseTimeline', () => {
             ]);
         });
     });
-    describe('shortlistingMethods', () => {
-        it('formats and returns', () => {
-            timelineArray = { 
-                shortlistingMethods: [
-                    'name-blind-paper-sift',
-                    'telephone-assessment',
-                ],
-            };
-            expect(exerciseTimeline(timelineArray)).toEqual([
-                {
-                    'date': undefined,
-                    'dateString': '',
-                    'entry': 'Name-blind sift',
-                },
-                {
-                    'date': undefined,
-                    'dateString': '',
-                    'entry': 'Telephone assessment',
-                },
-            ]);
-        });
-    });
     describe('shortlistingOutcomeDate', () => {
         it('formats and returns', () => {
             timelineArray = { 


### PR DESCRIPTION
Removed timeline items
---
## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
- Visit an exercise you know has a name-blind sift and phone assessment on admin ([example](http://admin-develop.judicialappointments.digital/exercises/ZFF4xU8zNvneljZ8Ynsm/timeline))
- Visit the [corresponding vacancy page on apply](http://apply-develop.judicialappointments.digital/vacancy/ZFF4xU8zNvneljZ8Ynsm/)
- Ensure name-blind sift and Telephone assessment don't show on timeline

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_