### PR TITLE
#798 Apply for role page for existing exercises

### DIFF
--- a/src/helpers/exerciseHelper.js
+++ b/src/helpers/exerciseHelper.js
@@ -425,14 +425,14 @@ function applicationParts(data) {
     }
     return applicationParts;
   }
-  return {};
+  return applicationPartsMap(data); // default to all relevant parts
 }
 // application parts in current stage (n.b. returns registration by default)
 function currentApplicationParts(data) {
   if (data._applicationContent) {
     return data._applicationContent[currentState(data)];
   }
-  return [];
+  return applicationPartsMap(data); // default to all relevant parts
 }
 // are there application parts in current stage (not registration)
 function isMoreInformationNeeded(exercise, application) {


### PR DESCRIPTION
## What's included?
Ensure the **apply for this role** page works as expected for existing exercises

## Who should test?
✅ Developers

## How to test?
See comments in ticket #798 for the bug report with actual and expected behavior.
The expected behavior should be working again.
Pick a vacancy which has not been configured as a staged application. Apply for it and observe the **Apply for the role** page. 

Example vacancy on preview URL: 
https://jac-apply-develop--pr803-feature-798-fix-task-azr17awd.web.app/apply/0j6GSbYUQOqoGDCDmCok

Same example before this fix:
https://jac-apply-develop--pr799-feature-798-applicat-wq0la3d4.web.app/apply/0j6GSbYUQOqoGDCDmCok

Before:
<img width="431" alt="image" src="https://user-images.githubusercontent.com/8524401/124934604-c8e2ee00-dffc-11eb-8011-a10cae4efebf.png">


After:
<img width="435" alt="image" src="https://user-images.githubusercontent.com/8524401/124934697-dd26eb00-dffc-11eb-8856-fe58b39becb8.png">


## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
