### PR TITLE
#1438 Moved sign-up link to future vacancies

### DIFF
--- a/src/views/Vacancies.vue
+++ b/src/views/Vacancies.vue
@@ -125,16 +125,6 @@
                 <p v-if="vacancy.roleSummary">
                   {{ vacancy.roleSummary }}
                 </p>
-                <p
-                  v-if="showSignUp(vacancy)"
-                  class="govuk-body govuk-!-margin-bottom-7"
-                >
-                  <a
-                    class="govuk-link govuk-body"
-                    :href="vacancy.subscriberAlertsUrl"
-                    target="_blank"
-                  >Sign up</a> for an alert about this exercise
-                </p>
                 <hr>
               </div>
 
@@ -173,16 +163,6 @@
                   </p>
                   <p v-if="vacancy.roleSummaryWelsh">
                     {{ vacancy.roleSummaryWelsh }}
-                  </p>
-                  <p
-                    v-if="showSignUp(vacancy)"
-                    class="govuk-body govuk-!-margin-bottom-7"
-                  >
-                    <a
-                      class="govuk-link govuk-body"
-                      :href="vacancy.subscriberAlertsUrl"
-                      target="_blank"
-                    >Ymunwch</a> os ydych am gael rhybudd am y swyddi uchod
                   </p>
                   <hr>
                 </div>
@@ -235,6 +215,16 @@
               <p v-if="vacancy.roleSummary">
                 {{ vacancy.roleSummary }}
               </p>
+              <p
+                v-if="vacancy.subscriberAlertsUrl"
+                class="govuk-body govuk-!-margin-bottom-5"
+              >
+                <a
+                  class="govuk-link govuk-body"
+                  :href="vacancy.subscriberAlertsUrl"
+                  target="_blank"
+                >Sign up</a> for an alert about this exercise
+              </p>
               <p>
                 <RouterLink
                   v-if="vacancy.aboutTheRole"
@@ -274,6 +264,16 @@
                 </p>
                 <p v-if="vacancy.roleSummaryWelsh">
                   {{ vacancy.roleSummaryWelsh }}
+                </p>
+                <p
+                  v-if="vacancy.subscriberAlertsUrl"
+                  class="govuk-body govuk-!-margin-bottom-5"
+                >
+                  <a
+                    class="govuk-link govuk-body"
+                    :href="vacancy.subscriberAlertsUrl"
+                    target="_blank"
+                  >Ymunwch</a> os ydych am gael rhybudd am y swyddi uchod
                 </p>
                 <p>
                   <RouterLink
@@ -438,19 +438,6 @@ export default {
   },
   created() {
     this.$store.dispatch('vacancies/bind');
-  },
-  methods: {
-    showSignUp(vacancy) {
-      if (vacancy.subscriberAlertsUrl) {
-        const openDate = this.$store.getters['vacancy/getOpenDate'];
-        if (openDate) {
-          const today = new Date();
-          return openDate > today;
-        }
-        return true;
-      }
-      return false;
-    },
   },
 };
 </script>


### PR DESCRIPTION
## What's included?
A sign up link (subscriber alerts url) was moved to be displayed under vacancies in Future applications section.

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?

- On Admin, go to an exercise that is not open yet, but published on the website (under Future applications). 
- Enter a subscriber alerts url into Website listing section.
- Go to Apply platform, this link should display under this exercise's description.
- - If 'Are there Welsh posts' question ticked in Website section, Welsh translation including the sign up link should be listed under the English version.
- On Admin, enter the subscriber alerts url into Website listing of an open/closed exercise. The link should not display under these exercises on Apply.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work
🟠 Medium risk - this does change code that is shared with other areas
🔴 High risk - this includes a lot of changes to shared code

## Additional context
[Here is the video of the required functionality.](https://drive.google.com/file/d/1EF-fO_1NKMVX1hmhq4Khd8yVWJX8tgST/view?usp=sharing)

![Sign up link](https://user-images.githubusercontent.com/40855898/126310641-8f860677-3fc2-41b8-898b-044c773a430d.png)


---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
