### PR TITLE
#809 Statement of eligibility fixes

### DIFF
--- a/src/components/Breadcrumb.vue
+++ b/src/components/Breadcrumb.vue
@@ -1,20 +1,27 @@
 <template>
   <div class="breadcrumb govuk-breadcrumbs">
     <ol class="govuk-breadcrumbs__list">
-        <li class="govuk-breadcrumbs__list-item">
-            <span><router-link to="/" class="govuk-breadcrumbs__link">Home</router-link></span>
-        </li>
-    <li class="govuk-breadcrumbs__list-item"
-      v-for="(item, index) in breadcrumbs"
-      :key="index"
-    >
-      <span v-if="item.isLastItem">
-        {{ item.title }}
-      </span>
-      <span v-else>
-        <router-link :to="item.href" class="govuk-breadcrumbs__link">{{ item.title }}</router-link>
-      </span>
-    </li>
+      <li class="govuk-breadcrumbs__list-item">
+        <span><router-link
+          to="/"
+          class="govuk-breadcrumbs__link"
+        >Home</router-link></span>
+      </li>
+      <li
+        v-for="(item, index) in breadcrumbs"
+        :key="index"
+        class="govuk-breadcrumbs__list-item"
+      >
+        <span v-if="item.isLastItem">
+          {{ item.title }}
+        </span>
+        <span v-else>
+          <router-link
+            :to="item.href"
+            class="govuk-breadcrumbs__link"
+          >{{ item.title }}</router-link>
+        </span>
+      </li>
     </ol>
   </div>
 </template>

--- a/src/helpers/exerciseHelper.js
+++ b/src/helpers/exerciseHelper.js
@@ -238,7 +238,7 @@ function hasCV(data) {
 function hasStatementOfEligibility(data) {
   switch (data.assessmentOptions) {
     case 'statement-of-eligibility':
-      return true;
+      return !!(data.aSCApply && data.selectionCriteria && data.selectionCriteria.length);
     default:
       return false;
   }

--- a/src/views/Apply/Assessments/StatementOfEligibility.vue
+++ b/src/views/Apply/Assessments/StatementOfEligibility.vue
@@ -31,7 +31,7 @@
 
             <RadioGroup
               :id="`meet_requirements_${index}`"
-              v-model="application.selectionCriteriaAnswers[index].answer"
+              v-model="item.answer"
               label="Do you meet this requirement?"
             >
               <RadioItem
@@ -40,7 +40,7 @@
               >
                 <TextareaInput
                   :id="`meet_requirements_details${index}`"
-                  v-model="application.selectionCriteriaAnswers[index].answerDetails"
+                  v-model="item.answerDetails"
                   label="In 250 words, tell us how."
                   required
                 />


### PR DESCRIPTION
## What's included?
Fixes a bug where Statement of Eligibility is being requested when it has not been fully configured. See #809 for more info.

**Note**
- the `exerciseHelper` file is identical between `apply` and `admin` repos. It will be moved to `jac-kit` once it has been in flight a little longer

## Who should test?
✅ Developers

## How to test?
In admin, set up an exercise so that it requests a Statement of Eligibility as part of the Assessment Options - remember to also complete the Additional Selection Criteria fields on the Eligibility Information page.
In apply, apply for the exercise/vacancy and observe that the Statement of Eligibility link appears on the **Apply for the role** (task list) page.
In admin turn off ASC and observe in Apply task list that the Statement of Eligibility link is no longer present. 

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work