### PR TITLE
ASC can handle custom word limits

### DIFF
--- a/src/views/Apply/Assessments/SelfAssessmentCompetencies.vue
+++ b/src/views/Apply/Assessments/SelfAssessmentCompetencies.vue
@@ -14,7 +14,7 @@
 
         <div v-if="formData && vacancy.aSCApply && vacancy.selectionCriteria">
           <div
-            v-for="(item, index) in formData.selectionCriteriaAnswers"
+            v-for="(item, index) in vacancy.selectionCriteria"
             :key="index"
           >
             <p
@@ -31,7 +31,7 @@
 
             <RadioGroup
               :id="`meet_requirements_${index}`"
-              v-model="item.answer"
+              v-model="formData.selectionCriteriaAnswers[index].answer"
               label="Do you meet this requirement?"
             >
               <RadioItem
@@ -40,9 +40,9 @@
               >
                 <TextareaInput
                   :id="`meet_requirements_details${index}`"
-                  v-model="item.answerDetails"
-                  :word-limit="250"
-                  hint="in 250 words tell us how."
+                  v-model="formData.selectionCriteriaAnswers[index].answerDetails"
+                  :word-limit="item.wordLimit || 250"
+                  :hint="`in ${item.wordLimit || 250} words tell us how.`"
                   :label="item.title"
                   label-hidden
                   required

--- a/src/views/Apply/Assessments/StatementOfEligibility.vue
+++ b/src/views/Apply/Assessments/StatementOfEligibility.vue
@@ -14,7 +14,7 @@
 
         <div v-if="formData && vacancy.aSCApply && vacancy.selectionCriteria">
           <div
-            v-for="(item, index) in formData.selectionCriteriaAnswers"
+            v-for="(item, index) in vacancy.selectionCriteria"
             :key="index"
           >
             <p
@@ -31,7 +31,7 @@
 
             <RadioGroup
               :id="`meet_requirements_${index}`"
-              v-model="item.answer"
+              v-model="formData.selectionCriteriaAnswers[index].answer"
               label="Do you meet this requirement?"
             >
               <RadioItem
@@ -40,9 +40,9 @@
               >
                 <TextareaInput
                   :id="`meet_requirements_details${index}`"
-                  v-model="item.answerDetails"
-                  :word-limit="250"
-                  hint="in 250 words tell us how."
+                  v-model="formData.selectionCriteriaAnswers[index].answerDetails"
+                  :word-limit="item.wordLimit || 250"
+                  :hint="`in ${item.wordLimit || 250} words tell us how.`"
                   :label="item.title"
                   label-hidden
                   required

--- a/src/views/Apply/Assessments/StatementOfSuitability.vue
+++ b/src/views/Apply/Assessments/StatementOfSuitability.vue
@@ -14,7 +14,7 @@
 
         <div v-if="vacancy.aSCApply && vacancy.selectionCriteria">
           <div
-            v-for="(item, index) in formData.selectionCriteriaAnswers"
+            v-for="(item, index) in vacancy.selectionCriteria"
             :key="index"
           >
             <p
@@ -31,7 +31,7 @@
 
             <RadioGroup
               :id="`meet_requirements_${index}`"
-              v-model="item.answer"
+              v-model="formData.selectionCriteriaAnswers[index].answer"
               label="Do you meet this requirement?"
             >
               <RadioItem
@@ -40,9 +40,9 @@
               >
                 <TextareaInput
                   :id="`meet_requirements_details${index}`"
-                  v-model="item.answerDetails"
-                  :word-limit="250"
-                  hint="in 250 words tell us how."
+                  v-model="formData.selectionCriteriaAnswers[index].answerDetails"
+                  :word-limit="item.wordLimit || 250"
+                  :hint="`in ${item.wordLimit || 250} words tell us how.`"
                   :label="item.title"
                   label-hidden
                   required


### PR DESCRIPTION
## What's included?
ASC can now handle custom word limits, found in statement of suitability, statement of eligibility, and self assessment.
![image](https://user-images.githubusercontent.com/44227249/130102491-dc4319c4-56be-4121-a369-0a561ed996d9.png)

## Who should test?
✅ Product owner
✅ Developers

## How to test?
### test in conjunction with [apply 816](https://github.com/jac-uk/apply/pull/816).

## admin
 - Set up/edit an exercise to have ASC.
 - Add a question with a custom word limit
 
 ## apply
 - Navigate to the applications
 - Add a question with a custom word limit
 - Observe the limit is presented and works
 
 •note•  the word count functionality has already been tested this is strictly about the custom number

## Risk - how likely is this to impact other areas?
🟢 Low risk - this is a self-contained piece of work

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_