### PR TITLE
Security/769 weak passwords allowed in reset form

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -5,6 +5,7 @@ import store from '@/store';
 import SignIn from '@/views/SignIn';
 import SignUp from '@/views/SignUp';
 import ResetPassword from '@/views/ResetPassword';
+import ConfirmResetPassword from '@/views/ConfirmResetPassword';
 
 // Vacancies
 // import Website from '@/Website/Home';
@@ -699,6 +700,14 @@ const router = new Router({
       component: ResetPassword,
       meta: {
         title: 'Reset your password',
+      },
+    },
+    {
+      path: '/confirm-reset-password',
+      name: 'confirm-reset-password',
+      component: ConfirmResetPassword,
+      meta: {
+        title: 'Confirm your password reset',
       },
     },
   ],

--- a/src/views/ConfirmResetPassword.vue
+++ b/src/views/ConfirmResetPassword.vue
@@ -1,0 +1,102 @@
+<template>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <form
+        ref="formRef"
+        @submit.prevent="onSubmit"
+      >
+        <div class="govuk-grid-column-two-thirds">
+          <h1 class="gov-heading-xl">
+            Reset Password
+          </h1>
+
+          <div
+            v-if="resetSuccessful"
+            class="govuk-panel govuk-panel--confirmation"
+          >
+            <h1 class="govuk-panel__title">
+              Your password has been changed
+            </h1>
+            <h2 class="govuk-panel__body govuk-!-font-size-27 govuk-!-margin-top-7">
+              You may now <RouterLink
+                class="govuk-link"
+                data-module="govuk-button"
+                :to="{ name: 'sign-in' }"
+              >
+                sign in
+              </RouterLink> with your new password.
+            </h2>
+          </div>
+          <div v-if="!resetSuccessful">
+
+            <Password
+              id="password"
+              v-model="formData.password"
+              label="Password"
+              hint="For security reasons it should be 8 or more characters long, contain a mix of upper- and lower-case letters, at least one digit and special character (like £, #, @, !, %, -, &, *)."
+              type="new-password"
+              :min-length="8"
+              required
+            />
+
+            <button
+              type="submit"
+              class="govuk-button"
+            >
+              Confirm Password Reset
+            </button>
+          </div>
+        </div>
+      </form>
+    </div>
+  </div>
+</template>
+
+<script>
+import { auth } from '@/firebase';
+import Password from '../components/Form/Password';
+import Form from '../components/Form/Form';
+
+export default {
+  name: 'ConfirmResetPassword',
+  components: { Password },
+  extends: Form,
+  data() {
+    return {
+      resetSuccessful: false,
+      formData: {},
+      errors: [],
+      resetCode: null,
+    };
+  },
+  mounted() {
+    this.getResetCodeFromUrl();
+  },
+  methods: {
+    async onSubmit() {
+      await this.validate();
+      if (this.isValid()) {
+        try {
+          await auth().confirmPasswordReset(this.resetCode, this.formData.password);
+          this.resetSuccessful = true;
+        } catch (error) {
+          this.errors.push({ message: error.message });
+          this.scrollToTop();
+        }
+      }
+    },
+    getResetCodeFromUrl() {
+      const params = new URLSearchParams(window.location.search);
+      if (!params.has('oobCode')) {
+        this.$router.push({ name: 'not-found' });
+        return;
+      }
+      this.resetCode = params.get('oobCode');
+    },
+  },
+};
+</script>
+
+<style scoped>
+
+</style>

--- a/src/views/ConfirmResetPassword.vue
+++ b/src/views/ConfirmResetPassword.vue
@@ -27,8 +27,7 @@
               </RouterLink> with your new password.
             </h2>
           </div>
-          <div v-if="!resetSuccessful">
-
+          <div v-if="!resetSuccessful && validResetCode">
             <Password
               id="password"
               v-model="formData.password"
@@ -38,7 +37,6 @@
               :min-length="8"
               required
             />
-
             <button
               type="submit"
               class="govuk-button"
@@ -67,10 +65,12 @@ export default {
       formData: {},
       errors: [],
       resetCode: null,
+      validResetCode: false,
     };
   },
   mounted() {
     this.getResetCodeFromUrl();
+    this.ensureValidActionCode();
   },
   methods: {
     async onSubmit() {
@@ -92,6 +92,15 @@ export default {
         return;
       }
       this.resetCode = params.get('oobCode');
+    },
+    ensureValidActionCode() {
+      auth().checkActionCode(this.resetCode)
+        .then(() => {
+          this.validResetCode = true;
+        })
+        .catch(() => {
+          this.$router.push({ name: 'not-found' });
+        });
     },
   },
 };


### PR DESCRIPTION
# Note: This PR re-applies the changes from PR [778](https://github.com/jac-uk/apply/pull/778). This work has already been user tested just needs to be included in the main branch

PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_