### PR TITLE
digital-platform#657 Identify auto-submitted QTs

### DIFF
--- a/src/views/QualifyingTests/QualifyingTests.vue
+++ b/src/views/QualifyingTests/QualifyingTests.vue
@@ -223,7 +223,7 @@ export default {
       const startedOrCompleted = obj.status === QUALIFYING_TEST.STATUS.STARTED || obj.status === QUALIFYING_TEST.STATUS.COMPLETED;
       const timeout = this.isTimeOut(obj.status, obj.statusLog.completed, this.isTimeLeft(obj));
       if (timeout) {
-        return 'Completed - Out of time';
+        return 'Completed (auto-submitted)';
       }
       if (startedOrCompleted) {
         return obj.status;


### PR DESCRIPTION
## What's included?
Simple change to replace the wording "Out of time" with "(auto-submitted)" for QTs.
See /jac-uk/digital-platform/issues/657 for details

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Log in to the apply site and navigate to Online Tests. Notice that an auto-submitted test now says 'Completed (auto-submitted)' instead of 'Completed - Out of Time'. See screen grab below.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context

**Before**
<img width="812" alt="image" src="https://user-images.githubusercontent.com/8524401/149951437-d7cbddaa-7583-4d6b-8464-d0401e8642f2.png">

**After**
<img width="802" alt="image" src="https://user-images.githubusercontent.com/8524401/149951919-915cd556-d000-472f-963e-56c6e5afc1e1.png">


---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
