### PR TITLE
Hotfix. Candidate can amend submitted application

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "application-form",
-  "version": "1.53.0",
+  "version": "1.53.1",
   "private": true,
   "scripts": {
     "preinstall": "npx npm-force-resolutions",

--- a/src/components/Page/TaskDetails.vue
+++ b/src/components/Page/TaskDetails.vue
@@ -29,9 +29,9 @@
         <option
           v-for="option in ['full-time', 'salaried-part-time', 'fee-paid', 'voluntary']"
           :key="option"
-          :value="option | filter"
+          :value="option | lookup"
         >
-          {{ option | filter }}
+          {{ option | lookup }}
         </option>
       </Select>
 

--- a/src/helpers/exerciseHelper.js
+++ b/src/helpers/exerciseHelper.js
@@ -468,7 +468,7 @@ function hasApplicationProcess(exercise) {
 }
 
 function informationDeadline(exercise) {
-  if (!exercise) { return false; }
+  if (!exercise) { return null; }
   if (hasApplicationProcess(exercise)) {
     if (exercise._applicationContent && exercise._applicationContent._currentStep && exercise._applicationContent._currentStep.end) {
       return exercise._applicationContent._currentStep.end;

--- a/src/helpers/exerciseHelper.js
+++ b/src/helpers/exerciseHelper.js
@@ -55,7 +55,8 @@ export {
   currentApplicationParts,
   isMoreInformationNeeded,
   isApplicationComplete,
-  hasApplicationProcess
+  hasApplicationProcess,
+  informationDeadline
 };
 
 // const EXERCISE_STATES = ['draft', 'ready', 'approved', 'shortlisting', 'selection', 'recommendation', 'handover', 'archived'];
@@ -464,4 +465,14 @@ function hasApplicationProcess(exercise) {
   if (!exercise) { return false; }
   const applicationSteps = configuredApplicationContentSteps(exercise);
   return applicationSteps.length >= 1;
+}
+
+function informationDeadline(exercise) {
+  if (!exercise) { return false; }
+  if (hasApplicationProcess(exercise)) {
+    if (exercise._applicationContent && exercise._applicationContent._currentStep && exercise._applicationContent._currentStep.end) {
+      return exercise._applicationContent._currentStep.end;
+    }
+  }
+  return null;
 }

--- a/src/views/Applications.vue
+++ b/src/views/Applications.vue
@@ -65,6 +65,14 @@
                   Data is temporarily unavailable.
                 </div>
                 <div v-else>
+                  <div v-if="canContinueWithApplication(application)">
+                    <div
+                      v-if="hasCompletedMoreInformation(application)"
+                      class="govuk-body-s govuk-!-margin-top-0 govuk-!-margin-bottom-1"
+                    >
+                      Your application is complete and <strong>has been received</strong>. However you can continue to make changes until 13:00 on {{ informationDeadline(application) | formatDate }}.
+                    </div>
+                  </div>
                   <RouterLink
                     v-if="canContinueWithApplication(application)"
                     :class="`govuk-button moj-button-menu__item info-link--applications--continue-with-application-${application.exerciseId}`"
@@ -72,7 +80,8 @@
                     role="button"
                     data-module="govuk-button"
                   >
-                    Continue with application
+                    <span v-if="hasCompletedMoreInformation(application)">Amend application</span>
+                    <span v-else>Continue with application</span>
                   </RouterLink>
                   <RouterLink
                     v-else
@@ -127,7 +136,7 @@ import {
   mapState
 } from 'vuex';
 import isVacancyOpen from '@/helpers/isVacancyOpen';
-import { isMoreInformationNeeded } from '@/helpers/exerciseHelper';
+import { isMoreInformationNeeded, isApplicationComplete, informationDeadline } from '@/helpers/exerciseHelper';
 
 export default {
   computed: {
@@ -155,13 +164,30 @@ export default {
       case 'draft':
         return isVacancyOpen(vacancy.applicationOpenDate, vacancy.applicationCloseDate, application.dateExtension);
       case 'applied':
-        // check whether extra info is needed
         return isMoreInformationNeeded(vacancy, application);
       default:
         return false;
       }
     },
-
+    hasCompletedMoreInformation(application) {
+      if (!application) return false;
+      const vacancy = this.$store.getters['vacancies/getVacancy'](application.exerciseId);
+      if (!vacancy) return false;
+      if (isMoreInformationNeeded(vacancy, application)) {
+        if (isApplicationComplete(vacancy, application)) {
+          return true;
+        }
+      }
+      return false;
+    },
+    informationDeadline(application) {
+      if (!application) return false;
+      const vacancy = this.$store.getters['vacancies/getVacancy'](application.exerciseId);
+      if (!vacancy) return false;
+      if (isMoreInformationNeeded(vacancy, application)) {
+        return informationDeadline(vacancy);
+      }
+    },
   },
 };
 </script>


### PR DESCRIPTION
## What's included?
Fixes the messaging candidates receive when completing a staged application.

**Before**
When the candidate has provided and submitted the next stage of their application they were seeing the following in the Applications list:
<img width="365" style="border: 1px solid black" alt="image" src="https://user-images.githubusercontent.com/8524401/152333652-bc551f24-f074-4739-a95e-38d4e7f4f3d3.png">
This caused confusion over whether their application had been received

**After**
When the candidate has provided and submitted the next stage of their application they now see the following in the Applications list:
<img width="1100" alt="image" src="https://user-images.githubusercontent.com/8524401/152333815-1afd7e0a-d0ec-4874-aa09-cc6390eb15b8.png">



## Who should test?
✅ Product owner
✅ Developers

## How to test?
You'll need an exercise which has a staged application process and an application to that exercise which has completed the first stage of the process and now needs to complete the next stage. See [this miro](https://miro.com/app/board/uXjVOQEj7rg=/) for more detail.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
