### PR TITLE
Add env getters to store

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -12,6 +12,7 @@ import browserDetect from 'vue-browser-detect-plugin';
 if (process.env.NODE_ENV !== 'development') {
   Sentry.init({
     dsn: 'https://2366ef9baa1a49bb8aa29c5262757de9@sentry.io/1499367',
+    environment: store.getters.appEnvironment.toLowerCase(),
     integrations: [new Integrations.Vue({ Vue, attachProps: true })],
   });
 

--- a/src/store.js
+++ b/src/store.js
@@ -46,6 +46,22 @@ const store = new Vuex.Store({
     appVersion: (state) => {
       return state.packageVersion;
     },
+    appEnvironment: () => {
+      const projectId = process.env.VUE_APP_FIREBASE_PROJECT_ID;
+      if (projectId.indexOf('-develop') >= 0) {
+        return 'DEVELOP';
+      }
+      if (projectId.indexOf('-staging') >= 0) {
+        return 'STAGING';
+      }
+      if (projectId.indexOf('-production') >= 0) {
+        return 'PRODUCTION';
+      }
+      return '';
+    },
+    isProduction: (state, getters) => {
+      return getters.appEnvironment === 'PRODUCTION';
+    },
     whichEnv: (state) => {
       return state.env;
     },


### PR DESCRIPTION
## What's included?
Added env getters to `store.js` so that sentry can be configured to filter by environment. 
Should help with replication of sentry issues and triage.

## Who should test?
✅ Developers

## How to test?
Wait for sentry errors to roll in and confirm they can be filtered by environment.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
