### PR TITLE
Validation of postcode for Character Agency Report

### DIFF
--- a/src/components/Form/Address.vue
+++ b/src/components/Form/Address.vue
@@ -44,6 +44,7 @@
       v-model="value.postcode"
       required
       label="Postcode"
+      type="postcode"
     />
   </div>
 </template>

--- a/src/components/Form/FormField.vue
+++ b/src/components/Form/FormField.vue
@@ -57,6 +57,7 @@ export default {
         // eslint-disable-next-line
         email: /^\w+([\.\+-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,20})+$/,
         tel: /^\+?[\d() -]+/,
+        postcode: /^[A-Z]{1,2}\d[A-Z\d]?\s*\d[A-Z]{2}$/i,
       },
     };
   },
@@ -129,6 +130,14 @@ export default {
         if (this.type && this.type === 'number' && value && this.numMax) {
           if (value > this.numMax) {
             this.setError(`Please enter a number lower than ${this.numMax}`);
+          }
+        }
+
+        if (this.type && this.type === 'postcode' && value) {
+          value = value.trim().replace(/ /g, '').toUpperCase();
+          this.text = value;
+          if (!this.regex.postcode.test(value)) {
+            this.setError(`Enter a valid value for ${this.label}`);
           }
         }
 

--- a/tests/unit/components/Form/FormField.spec.js
+++ b/tests/unit/components/Form/FormField.spec.js
@@ -205,13 +205,21 @@
 
       describe('regex', () => {
           it('has email and telephone patterns', () => {
-            expect(data.regex).toContainAllKeys(['email', 'tel']);
+            expect(data.regex).toContainKeys(['email', 'tel']);
           });
           it('email matches pattern', () => {
             expect('test@test.com').toMatch(data.regex.email);
           });
           it('tel matches pattern', () => {
             expect('07123456789').toMatch(data.regex.tel);
+          });
+          it('has postcode pattern', () => {
+            expect(data.regex).toContainKeys(['postcode']);
+          });
+          it('postcode matches pattern', () => {
+            expect('181RJ').not.toMatch(data.regex.postcode);
+            expect('MK181RJ').toMatch(data.regex.postcode);
+            expect('MK18 1RJ').toMatch(data.regex.postcode);
           });
       });
     });


### PR DESCRIPTION
**Author checklist**

- [x] Include primary ticket number in title - e.g. "#123 New styling for widget" - and any additional tickets in description
- [x] Fill in the details below and delete as appropriate
- [x] Be proactive in getting your work approved 💪

---

## What's included?
Add validation of postcode for Character Agency Report. The postcode value will be validated and formatted to capitalisation without space. E.g., "SW1a 2AA" will be formatted to "SW1A2AA".

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Preview URL: https://jac-apply-develop--pr882-feature-validate-pos-hazxh5nq.web.app

1.【apply site】
- Apply for an exercise.

2.【admin site】
- Go to the exercise
- Go to `Character Checks` on `Tasks`
- Select the application and click `send requests`

3.【apply site】 
- Go to `applications`
- Click `Complete character checks consent form`
- Type in "Postcode" field with valid postcode value

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Demo:

https://user-images.githubusercontent.com/79906532/173388096-d0081ac7-b974-4f63-94d6-6adb459dd311.mov

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
