### PR TITLE
#881 Send email to candidate when Character Agency report submitted

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -16,6 +16,7 @@ import qualifyingTestResponses from '@/store/qualifyingTestResponses';
 import logs from '@/store/logs';
 import connectionMonitor from '@/store/connectionMonitor';
 import session from '@/store/session';
+import exercise from '@/store/exercise';
 
 const store = new Vuex.Store({
   // Don't use strict mode in production for performance reasons (https://vuex.vuejs.org/guide/strict.html)
@@ -33,6 +34,7 @@ const store = new Vuex.Store({
     logs,
     connectionMonitor,
     session,
+    exercise,
   },
   state: {
     packageVersion: process.env.PACKAGE_VERSION || '0',

--- a/src/store/exercise.js
+++ b/src/store/exercise.js
@@ -1,0 +1,21 @@
+import { firestore } from '@/firebase';
+import { firestoreAction } from 'vuexfire';
+import vuexfireSerialize from '@/helpers/vuexfireSerialize';
+
+const collection = firestore.collection('exercises');
+
+export default {
+  namespaced: true,
+  actions: {
+    bind: firestoreAction(({ bindFirestoreRef }, id) => {
+      const firestoreRef = collection.doc(id);
+      return bindFirestoreRef('record', firestoreRef, { serialize: vuexfireSerialize });
+    }),
+    unbind: firestoreAction(({ unbindFirestoreRef }) => {
+      return unbindFirestoreRef('record');
+    }),
+  },
+  state: {
+    record: null,
+  },
+};


### PR DESCRIPTION
**Author checklist**

- [x] Include primary ticket number in title - e.g. "#123 New styling for widget" - and any additional tickets in description
- [x] Fill in the details below and delete as appropriate
- [x] Be proactive in getting your work approved 💪

---

## What's included?
Send email to candidate when Character Agency report submitted

Note: This issue is related to [#881 character check consent form submit template](https://github.com/jac-uk/digital-platform/pull/733).

**Update:** Use a database trigger to deal with sending email when the character checks consent form is submitted. No need to do any changes on apply repo.

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Preview URL: https://jac-apply-develop--pr887-feature-881-send-ema-o40xcdtw.web.app

1.【apply site】
- Apply for an exercise.

2.【admin site】
- Go to the exercise
- Go to `Character Checks` on `Tasks`
- Select the application and click `send requests`

3.【apply site】 
- Go to `applications`
- Click `Complete character checks consent form`
- Submit character agency report
- Check email sent

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Demo:

https://user-images.githubusercontent.com/79906532/174025159-bfaac313-98b6-4ecd-8684-71705dd0c69b.mov

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
