### PR TITLE
change-application-confirmation-message

### DIFF
--- a/src/views/Apply/FinalCheck/Confirmation.vue
+++ b/src/views/Apply/FinalCheck/Confirmation.vue
@@ -20,18 +20,7 @@
         {{ application.personalDetails.email }}
       </p> -->
 
-      <div v-if="vacancy.referenceNumber === 'JAC00014'">
-        <h2 class="govuk-heading-m">
-          What happens next?
-        </h2>
-
-        <p class="govuk-body">
-          We’ll contact you by 9 March 2020 to advise whether an online qualifying
-          test will be taking place. If you’ve not heard from us by this date,
-          please contact the selection exercise team.
-        </p>
-      </div>
-      <div v-else-if="hasApplicationProcess">
+      <div v-if="hasApplicationProcess">
         <h2 class="govuk-heading-m">
           What happens next?
         </h2>
@@ -62,11 +51,16 @@
         <h2 class="govuk-heading-m">
           What happens next?
         </h2>
-        <p class="govuk-body">
+        <!-- <p class="govuk-body">
           We'll now decide if you should be shortlisted for this role.
         </p>
         <p class="govuk-body">
           We'll email you in {{ vacancy.shortlistingOutcomeDate | formatDate('month') }} to let you know either way.
+        </p> -->
+        <p class="govuk-body">
+          Thank you for your application.
+          We will be in touch in due course.
+          Please refer to the website for details of this selection exercise and dates of the next stage in the process.
         </p>
       </div>
 


### PR DESCRIPTION
## What's included?
Amendments to the message displayed to candidates upon completion of the application process. 

from >
          We'll email you in [DATE AND TIME] to let you know either way.
to >
          Thank you for your application.
          We will be in touch in due course.
          Please refer to the website for details of this selection exercise and dates of the next stage in the process.
          
As well as the removal of some unused code on this same page.

## Who should test?
✅ Product owner
✅ Developers

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
