### PR TITLE
#891 Show html text in vacancies

### DIFF
--- a/src/components/CustomHTML.vue
+++ b/src/components/CustomHTML.vue
@@ -1,0 +1,32 @@
+<template>
+  <div
+    class="custom-html"
+    v-html="value"
+  />
+</template>
+
+<script>
+export default {
+  name: 'CustomHTML',
+  props: {
+    value: {
+      type: String,
+      default: '',
+    },
+  },
+};
+</script>
+
+<style>
+/* customize nested ordered list (1.1, 1.2) */
+.custom-html ol {
+  counter-reset: item;
+}
+.custom-html ol li {
+  display: block;
+}
+.custom-html ol li::before {
+  counter-increment: item;
+  content: counters(item, '.') '. ';
+}
+</style>

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -112,3 +112,15 @@ body {
 .govuk-input:disabled {
   background-color: #ccc;
 }
+
+/* customize nested ordered list (1.1, 1.2) */
+.custom-ordered-list ol {
+  counter-reset: item;
+}
+.custom-ordered-list ol li {
+  display: block;
+}
+.custom-ordered-list ol li::before {
+  counter-increment: item;
+  content: counters(item, '.') '. ';
+}

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -112,15 +112,3 @@ body {
 .govuk-input:disabled {
   background-color: #ccc;
 }
-
-/* customize nested ordered list (1.1, 1.2) */
-.custom-ordered-list ol {
-  counter-reset: item;
-}
-.custom-ordered-list ol li {
-  display: block;
-}
-.custom-ordered-list ol li::before {
-  counter-increment: item;
-  content: counters(item, '.') '. ';
-}

--- a/src/views/Vacancies.vue
+++ b/src/views/Vacancies.vue
@@ -122,9 +122,11 @@
                     {{ vacancy.applicationCloseDate | formatDate('datetime') }}
                   </span>
                 </p>
-                <p v-if="vacancy.roleSummary">
-                  {{ vacancy.roleSummary }}
-                </p>
+                <p
+                  v-if="vacancy.roleSummary"
+                  class="custom-ordered-list"
+                  v-html="vacancy.roleSummary"
+                />
                 <hr>
               </div>
 
@@ -161,9 +163,11 @@
                       {{ vacancy.applicationCloseDate | formatDate('datetime') }}
                     </span>
                   </p>
-                  <p v-if="vacancy.roleSummaryWelsh">
-                    {{ vacancy.roleSummaryWelsh }}
-                  </p>
+                  <p
+                    v-if="vacancy.roleSummaryWelsh"
+                    class="custom-ordered-list"
+                    v-html="vacancy.roleSummaryWelsh"
+                  />
                   <hr>
                 </div>
               </div>
@@ -212,9 +216,11 @@
                   {{ vacancy.estimatedLaunchDate | formatEstimatedDate }}
                 </span>
               </p>
-              <p v-if="vacancy.roleSummary">
-                {{ vacancy.roleSummary }}
-              </p>
+              <p
+                v-if="vacancy.roleSummary"
+                class="custom-ordered-list"
+                v-html="vacancy.roleSummary"
+              />
               <p
                 v-if="vacancy.subscriberAlertsUrl"
                 class="govuk-body govuk-!-margin-bottom-5"
@@ -262,9 +268,11 @@
                     {{ vacancy.estimatedLaunchDate | formatEstimatedDate }}
                   </span>
                 </p>
-                <p v-if="vacancy.roleSummaryWelsh">
-                  {{ vacancy.roleSummaryWelsh }}
-                </p>
+                <p
+                  v-if="vacancy.roleSummaryWelsh"
+                  class="custom-ordered-list"
+                  v-html="vacancy.roleSummaryWelsh"
+                />
                 <p
                   v-if="vacancy.subscriberAlertsUrl"
                   class="govuk-body govuk-!-margin-bottom-5"
@@ -340,9 +348,11 @@
                   {{ vacancy.applicationCloseDate | formatDate('datetime') }}
                 </span>
               </p>
-              <p v-if="vacancy.roleSummary">
-                {{ vacancy.roleSummary }}
-              </p>
+              <p
+                v-if="vacancy.roleSummary"
+                class="custom-ordered-list"
+                v-html="vacancy.roleSummary"
+              />
               <p>
                 <RouterLink
                   v-if="vacancy.aboutTheRole"
@@ -393,9 +403,11 @@
                     {{ vacancy.applicationCloseDate | formatDate('datetime') }}
                   </span>
                 </p>
-                <p v-if="vacancy.roleSummaryWelsh">
-                  {{ vacancy.roleSummaryWelsh }}
-                </p>
+                <p
+                  v-if="vacancy.roleSummaryWelsh"
+                  class="custom-ordered-list"
+                  v-html="vacancy.roleSummaryWelsh"
+                />
                 <p>
                   <RouterLink
                     v-if="vacancy.aboutTheRole"

--- a/src/views/Vacancies.vue
+++ b/src/views/Vacancies.vue
@@ -122,10 +122,9 @@
                     {{ vacancy.applicationCloseDate | formatDate('datetime') }}
                   </span>
                 </p>
-                <p
+                <CustomHTML
                   v-if="vacancy.roleSummary"
-                  class="custom-ordered-list"
-                  v-html="vacancy.roleSummary"
+                  :value="vacancy.roleSummary"
                 />
                 <hr>
               </div>
@@ -163,10 +162,9 @@
                       {{ vacancy.applicationCloseDate | formatDate('datetime') }}
                     </span>
                   </p>
-                  <p
+                  <CustomHTML
                     v-if="vacancy.roleSummaryWelsh"
-                    class="custom-ordered-list"
-                    v-html="vacancy.roleSummaryWelsh"
+                    :value="vacancy.roleSummaryWelsh"
                   />
                   <hr>
                 </div>
@@ -216,10 +214,9 @@
                   {{ vacancy.estimatedLaunchDate | formatEstimatedDate }}
                 </span>
               </p>
-              <p
+              <CustomHTML
                 v-if="vacancy.roleSummary"
-                class="custom-ordered-list"
-                v-html="vacancy.roleSummary"
+                :value="vacancy.roleSummary"
               />
               <p
                 v-if="vacancy.subscriberAlertsUrl"
@@ -268,10 +265,9 @@
                     {{ vacancy.estimatedLaunchDate | formatEstimatedDate }}
                   </span>
                 </p>
-                <p
+                <CustomHTML
                   v-if="vacancy.roleSummaryWelsh"
-                  class="custom-ordered-list"
-                  v-html="vacancy.roleSummaryWelsh"
+                  :value="vacancy.roleSummaryWelsh"
                 />
                 <p
                   v-if="vacancy.subscriberAlertsUrl"
@@ -348,10 +344,9 @@
                   {{ vacancy.applicationCloseDate | formatDate('datetime') }}
                 </span>
               </p>
-              <p
+              <CustomHTML
                 v-if="vacancy.roleSummary"
-                class="custom-ordered-list"
-                v-html="vacancy.roleSummary"
+                :value="vacancy.roleSummary"
               />
               <p>
                 <RouterLink
@@ -403,10 +398,10 @@
                     {{ vacancy.applicationCloseDate | formatDate('datetime') }}
                   </span>
                 </p>
-                <p
+
+                <CustomHTML
                   v-if="vacancy.roleSummaryWelsh"
-                  class="custom-ordered-list"
-                  v-html="vacancy.roleSummaryWelsh"
+                  :value="vacancy.roleSummaryWelsh"
                 />
                 <p>
                   <RouterLink
@@ -437,8 +432,12 @@
 <script>
 import { mapGetters } from 'vuex';
 import { ADVERT_TYPES } from '@/helpers/constants';
+import CustomHTML from '@/components/CustomHTML';
 
 export default {
+  components: {
+    CustomHTML,
+  },
   computed: {
     ...mapGetters('vacancies', [
       'openVacancies',


### PR DESCRIPTION
## What's included?
Show HTML text (i.e., roleSummary, roleSummaryWelsh) on vacancies page.

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Preview URL: https://jac-apply-develop--pr892-feature-show-html-te-e6c5pe5n.web.app

1. Go to Vacancies
2. Check if role summary text is showing correctly.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Demo:

https://user-images.githubusercontent.com/79906532/181465828-553e21e6-7a15-4fef-b99c-58edf52f5b29.mov

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
