### PR TITLE
#896 Weak password policy for password reset

### DIFF
--- a/src/components/Form/Password.vue
+++ b/src/components/Form/Password.vue
@@ -61,6 +61,10 @@ export default {
       default: 'current-password',
       type: String,
     },
+    minLength: {
+      default: 8,
+      type: Number,
+    },
   },
   data() {
     return {
@@ -121,8 +125,8 @@ export default {
     },
     validatePassword(password) {
 
-      if (password.length < 8) {
-        this.setError(`${this.label} should be 8 or more characters long`);
+      if (password.length < this.minLength) {
+        this.setError(`${this.label} should be ${this.minLength} or more characters long`);
       }
 
       if (!this.regex.containsCapitalLetters.test(password)) {

--- a/src/views/ConfirmResetPassword.vue
+++ b/src/views/ConfirmResetPassword.vue
@@ -32,9 +32,9 @@
               id="password"
               v-model="formData.password"
               label="Password"
-              hint="For security reasons it should be 8 or more characters long, contain a mix of upper- and lower-case letters, at least one digit and special character (like £, #, @, !, %, -, &, *)."
+              :hint="`For security reasons it should be ${minPasswordLength} or more characters long, contain a mix of upper- and lower-case letters, at least one digit and special character (like £, #, @, !, %, -, &, *).`"
               type="new-password"
-              :min-length="8"
+              :min-length="minPasswordLength"
               required
             />
             <button
@@ -61,6 +61,7 @@ export default {
   extends: Form,
   data() {
     return {
+      minPasswordLength: 12,
       resetSuccessful: false,
       formData: {},
       errors: [],

--- a/src/views/SignUp.vue
+++ b/src/views/SignUp.vue
@@ -75,9 +75,9 @@
             id="password"
             v-model="formData.password"
             label="Password"
-            hint="For security reasons it should be 8 or more characters long, contain a mix of upper- and lower-case letters, at least one digit and special character (like £, #, @, !, %, -, &, *)."
+            :hint="`For security reasons it should be ${minPasswordLength} or more characters long, contain a mix of upper- and lower-case letters, at least one digit and special character (like £, #, @, !, %, -, &, *).`"
             type="new-password"
-            :min-length="8"
+            :min-length="minPasswordLength"
             required
           />
 
@@ -129,6 +129,7 @@ export default {
   extends: Form,
   data () {
     return {
+      minPasswordLength: 12,
       formData: {},
       fullName: null,
     };


### PR DESCRIPTION
## What's included?
During the ITHC the application was found to enforce a weak password policy for users when recovering their password.
In this PR the password policy length requirement be increased to `12` characters due to no multiple factor authentication on apply site.

<img width="711" alt="Screenshot 2022-08-09 at 13 07 33" src="https://user-images.githubusercontent.com/79906532/183643278-cd5381fd-f237-423c-accf-e77f6a5173bf.png">

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Preview URL: https://jac-apply-develop--pr902-feature-password-pol-p6o5lnvp.web.app

1. Go to `Create an account` and check the minimum password length is 12.
2. Go to `Reset Password` and check the minimum password length is 12.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Demo:

https://user-images.githubusercontent.com/79906532/183430644-8bb8c5a2-c45d-4ce2-abe6-1d55a2a287f5.mov

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
