### PR TITLE
#713 Candidate Unable to Enter Email Address with Apostrophe

### DIFF
--- a/src/components/Form/FormField.vue
+++ b/src/components/Form/FormField.vue
@@ -55,7 +55,7 @@ export default {
       checkErrors: false,
       regex: {
         // eslint-disable-next-line
-        email: /^\w+([\.\+-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,20})+$/,
+        email: /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/, // ref: https://emailregex.com/
         tel: /^\+?[\d() -]+/,
         nino: /^(?!BG|GB|NK|KN|TN|NT|ZZ)[A-CEGHJ-PR-TW-Z][A-CEGHJ-NPR-TW-Z](?:\s?\d){6}\s?[A-D]$/i,
         postcode: /^[A-Z]{1,2}\d[A-Z\d]?\s*\d[A-Z]{2}$/i,

--- a/tests/unit/components/Form/FormField.spec.js
+++ b/tests/unit/components/Form/FormField.spec.js
@@ -209,6 +209,51 @@
           });
           it('email matches pattern', () => {
             expect('test@test.com').toMatch(data.regex.email);
+            expect("test'test@test.com").toMatch(data.regex.email);
+
+            // test cases from https://en.wikipedia.org/wiki/Email_address
+            const validEmails = [
+              'simple@example.com',
+              'very.common@example.com',
+              'disposable.style.email.with+symbol@example.com',
+              'other.email-with-hyphen@example.com',
+              'fully-qualified-domain@example.com',
+              'user.name+tag+sorting@example.com',
+              'x@example.com',
+              'example-indeed@strange-example.com',
+              'test/test@test.com',
+              // 'admin@mailserver1',
+              'example@s.example',
+              '" "@example.org',
+              '"john..doe"@example.org',
+              'mailhost!username@example.org',
+              // eslint-disable-next-line no-useless-escape
+              '"very.(),:;<>[]\".VERY.\"very@\\ \"very\".unusual"@strange.example.com',
+              'user%example.com@example.org',
+              'user-@example.org',
+              'postmaster@[123.123.123.123]',
+              // 'postmaster@[IPv6:2001:0db8:85a3:0000:0000:8a2e:0370:7334]',
+            ];
+            const invalidEmails = [
+              'Abc.example.com',
+              'A@b@c@example.com',
+              // eslint-disable-next-line no-useless-escape
+              'a"b(c)d,e:f;g<h>i[j\k]l@example.com',
+              'just"not"right@example.com',
+              // eslint-disable-next-line no-useless-escape
+              'this is"not\allowed@example.com',
+              // eslint-disable-next-line no-useless-escape
+              'this\ still\"not\\allowed@example.com',
+              // '1234567890123456789012345678901234567890123456789012345678901234+x@example.com',
+              'i_like_underscore@but_its_not_allowed_in_this_part.example.com',
+              'QA[icon]CHOCOLATE[icon]@test.com',
+            ];
+            validEmails.forEach(email => {
+              expect(email).toMatch(data.regex.email);
+            });
+            invalidEmails.forEach(email => {
+              expect(email).not.toMatch(data.regex.email);
+            });
           });
           it('tel matches pattern', () => {
             expect('07123456789').toMatch(data.regex.tel);


### PR DESCRIPTION
## What's included?
Refine email validation to accept apostrophe in email address.

Note: there is no perfect email regex so far. I just found the one that match the most use cases.

Regex reference: https://emailregex.com/
Email test cases: https://en.wikipedia.org/wiki/Email_address

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Preview URL: https://jac-apply-develop--pr906-feature-713-refine-e-ok7kejkv.web.app

1. Enter the email address with apostrophe for independent assessor 

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, notes etc.

---
PREVIEW:DEVELOP
