### PR TITLE
#912 Select Assessor Type

### DIFF
--- a/src/filters.js
+++ b/src/filters.js
@@ -1,4 +1,4 @@
-import { QUALIFYING_TEST } from '@/helpers/constants';
+import { QUALIFYING_TEST, ASSESSOR_TYPES } from '@/helpers/constants';
 
 const capitalize = (value) => {
   if (!value) return '';
@@ -294,6 +294,10 @@ const lookup = (value) => {
     lookup[QUALIFYING_TEST.TYPE.SCENARIO] = 'Scenario';
     lookup[QUALIFYING_TEST.TYPE.CRITICAL_ANALYSIS] = 'Critical analysis';
     lookup[QUALIFYING_TEST.TYPE.SITUATIONAL_JUDGEMENT] = 'Situational judgement';
+
+    lookup[ASSESSOR_TYPES.PROFESSIONAL] = 'Professional assessor';
+    lookup[ASSESSOR_TYPES.JUDICIAL] = 'Judicial assessor';
+    lookup[ASSESSOR_TYPES.PERSONAL] = 'Personal assessor';
 
     return lookup[value] || value;
   }

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -49,6 +49,12 @@ const DEFAULT = {
 const WELSH_POSTS_CONTACT_MAILBOX = 'enquiries@judicialappointments.gov.uk';
 const WELSH_POSTS_EMAIL_SUBJECT = 'Welsh application form request';
 
+const ASSESSOR_TYPES = {
+  PROFESSIONAL: 'professional',
+  JUDICIAL: 'judicial',
+  PERSONAL: 'personal',
+};
+
 export {
   STATUS,
   QUALIFYING_TEST,
@@ -56,5 +62,6 @@ export {
   ADVERT_TYPES,
   DEFAULT,
   WELSH_POSTS_CONTACT_MAILBOX,
-  WELSH_POSTS_EMAIL_SUBJECT
+  WELSH_POSTS_EMAIL_SUBJECT,
+  ASSESSOR_TYPES
 };

--- a/src/views/Apply/Assessments/AssessorsDetails.vue
+++ b/src/views/Apply/Assessments/AssessorsDetails.vue
@@ -33,6 +33,57 @@
           before making your nominations.
         </p>
 
+        <details class="govuk-body-l">
+          <summary>Who to choose?</summary>
+          <div
+            class="govuk-body"
+            style="margin-top: 8px;"
+          >
+            <p>It is important that you choose the right assessor.</p>
+            <ul>
+              <li>if you are a salaried judicial office holder, you need 2 judicial assessors</li>
+              <li>if you are a professional with one or more fee-paid judicial roles, you need one professional and one judicial assessor; the judicial assessor should be the judge who can provide examples most relevant to the role for which you are applying</li>
+              <li>if you do not hold judicial office and you are employed, you will usually need 2 professional assessors, or for some exercises you can provide one professional and one personal assessor</li>
+            </ul>
+
+            <p>For <strong>judicial roles</strong> ideally you should choose someone from your current employment or who has knowledge of your work in a judicial or professional capacity. If you work or practice independently, you may wish to choose someone (such as a judge) who has seen you practice and can provide good examples of your skills in relation to the required competencies.</p>
+
+            <p>A <u>professional assessor</u> could be:</p>
+            <ul>
+              <li>a senior partner or head of chambers</li>
+              <li>a judicial office holder who can give examples of your professional work</li>
+              <li>a client (including a local authority official) or a magistrate</li>
+              <li>a line manager if you are from a non-legal background; if there is no line manager, then a current or former colleague or client</li>
+            </ul>
+
+            <p>A <u>judicial assessor</u> could be:</p>
+            <ul>
+              <li>the senior judge of the court, jurisdiction or circuit where you sit most often</li>
+              <li>the Senior President or Lord President (Scotland) if you are a Chamber/Tribunal President</li>
+              <li>the Lord Justice Clerk or Sheriff Principal if you are a Sheriff (Scotland only)</li>
+              <li>your appraising judge if you sit on a tribunal</li>
+            </ul>
+
+            <p>If you are unable to provide one of the above, consider another judge who has first-hand knowledge of your work. If you are unable to provide any judicial assessor, please contact us giving your reasons writing.</p>
+            <p>If you are applying for a <strong>non-legal role</strong> you should choose assessors who know you well and who can give clear examples of your abilities.</p>
+            
+            <p>A <u>personal assessor</u> could be:</p>
+            <ul>
+              <li>a former colleague, manager or client who is familiar with the way you work</li>
+              <li>someone for whom you do voluntary work</li>
+            </ul>
+        
+            <p>If you have been on maternity leave or a career break, there is no time limit on how recently you have worked with your assessor, although where possible within the last 2 years is recommended so they can provide recent examples.</p>
+            
+            <p>Do not nominate:</p>
+            <ul>
+              <li>another individual who is applying for a role in the same exercise</li>
+              <li>a JAC commissioner</li>
+              <li>a relative (even if you work or have worked with them in a professional capacity)</li>
+            </ul>
+          </div>
+        </details>
+
         <h2 class="govuk-heading-l">
           First independent assessor
         </h2>

--- a/src/views/Apply/Assessments/AssessorsDetails.vue
+++ b/src/views/Apply/Assessments/AssessorsDetails.vue
@@ -37,6 +37,21 @@
           First independent assessor
         </h2>
 
+        <Select
+          id="first-assessor-type"
+          v-model="formData.firstAssessorType"
+          :value="formData.firstAssessorType"
+          label="Assessor type"
+          required
+        >
+          <option
+            v-for="option in assessorTypes"
+            :key="option"
+            :value="option"
+          >
+            {{ option | lookup }}
+          </option>
+        </Select>
         <TextField
           id="first-assessor-full-name"
           v-model="formData.firstAssessorFullName"
@@ -68,6 +83,21 @@
           Second independent assessor
         </h2>
 
+        <Select
+          id="second-assessor-type"
+          v-model="formData.secondAssessorType"
+          :value="formData.secondAssessorType"
+          label="Assessor type"
+          required
+        >
+          <option
+            v-for="option in assessorTypes"
+            :key="option"
+            :value="option"
+          >
+            {{ option | lookup }}
+          </option>
+        </Select>
         <TextField
           id="second-assessor-full-name"
           v-model="formData.secondAssessorFullName"
@@ -112,12 +142,15 @@ import ErrorSummary from '@/components/Form/ErrorSummary';
 import ApplyMixIn from '../ApplyMixIn';
 import TextField from '@/components/Form/TextField';
 import BackLink from '@/components/BackLink';
+import Select from '@jac-uk/jac-kit/draftComponents/Form/Select';
+import { ASSESSOR_TYPES } from '@/helpers/constants';
 
 export default {
   components: {
     ErrorSummary,
     TextField,
     BackLink,
+    Select,
   },
   extends: Form,
   mixins: [ApplyMixIn],
@@ -136,9 +169,16 @@ export default {
     const data = this.$store.getters['application/data'](defaults);
     const formData = { ...defaults, ...data };
     return {
+      assessorTypes: Object.values(ASSESSOR_TYPES),
       formId: 'assessorsDetails',
       formData: formData,
     };
   },
 };
 </script>
+
+<style>
+#first-assessor-type, #second-assessor-type {
+  width: 100%;
+}
+</style>

--- a/src/views/Apply/Assessments/AssessorsDetails.vue
+++ b/src/views/Apply/Assessments/AssessorsDetails.vue
@@ -34,7 +34,9 @@
         </p>
 
         <details class="govuk-body-l">
-          <summary>Who to choose?</summary>
+          <summary style="cursor: pointer;">
+            Who to choose?
+          </summary>
           <div
             class="govuk-body"
             style="margin-top: 8px;"

--- a/src/views/Apply/FinalCheck/Review.vue
+++ b/src/views/Apply/FinalCheck/Review.vue
@@ -547,6 +547,14 @@
             <dl class="govuk-summary-list">
               <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">
+                  Assessor Type
+                </dt>
+                <dd class="govuk-summary-list__value">
+                  {{ application.firstAssessorType | lookup }}
+                </dd>
+              </div>
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
                   Full name
                 </dt>
                 <dd class="govuk-summary-list__value">
@@ -574,6 +582,14 @@
 
               <hr class="govuk-section-break govuk-section-break--xl">
 
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                  Assessor Type
+                </dt>
+                <dd class="govuk-summary-list__value">
+                  {{ application.secondAssessorType | lookup }}
+                </dd>
+              </div>
               <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">
                   Full name


### PR DESCRIPTION
## What's included?
Add assessor type selection.
- Professional assessor
- Judicial assessor
- Personal assessor

Note: the phone validation will be not included in this PR but it will be in [#900 Input validation - phone numbers](https://github.com/jac-uk/apply/pull/903).

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Preview URL: https://jac-apply-develop--pr911-feature-1690-update-60yk6p1l.web.app

1. Apply for a vacancy.
2. Go to Independent assessors' details and select assessor type.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Demo:

https://user-images.githubusercontent.com/79906532/186365128-9886c251-8b07-4121-8851-bd167ec2447d.mov

---
PREVIEW:DEVELOP
