### PR TITLE
#898 Missing Application Security Headers

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -85,6 +85,18 @@
             {
               "key": "Cache-Control",
               "value": "max-age=300, s-maxage=3600, public"
+            },
+            {
+              "key": "Strict-Transport-Security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "key": "X-Content-Type-Options",
+              "value": "nosniff"
+            },
+            {
+              "key": "X-Frame-Options",
+              "value": "DENY"
             }
           ]
         },
@@ -147,6 +159,18 @@
             {
               "key": "Cache-Control",
               "value": "max-age=150, s-maxage=1800, public"
+            },
+            {
+              "key": "Strict-Transport-Security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "key": "X-Content-Type-Options",
+              "value": "nosniff"
+            },
+            {
+              "key": "X-Frame-Options",
+              "value": "DENY"
             }
           ]
         },

--- a/firebase.json
+++ b/firebase.json
@@ -20,6 +20,18 @@
             {
               "key": "Cache-Control",
               "value": "max-age=300, s-maxage=3600, public"
+            },
+            {
+              "key": "Strict-Transport-Security",
+              "value": "max-age=31536000; includeSubDomains"
+            },
+            {
+              "key": "X-Content-Type-Options",
+              "value": "nosniff"
+            },
+            {
+              "key": "X-Frame-Options",
+              "value": "DENY"
             }
           ]
         },


### PR DESCRIPTION

## What's included?

#898 
Added the following headers:

`          {
              "key": "Strict-Transport-Security",
              "value": "max-age=31536000; includeSubDomains"
            },
            {
              "key": "X-Content-Type-Options",
              "value": "nosniff"
            },
            {
              "key": "X-Frame-Options",
              "value": "DENY"
            }`

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
go to https://jac-apply-develop--898-lee-gyzes5i3.web.app/vacancies and check the headers

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, notes etc.
![image](https://user-images.githubusercontent.com/15261814/187493107-4c107e15-41f5-45a2-b76e-934aed8a2190.png)

