### PR TITLE
Bugfix: #1741 Judicial experience details

### DIFF
--- a/src/views/Apply/QualificationsAndExperience/JudicialExperience.vue
+++ b/src/views/Apply/QualificationsAndExperience/JudicialExperience.vue
@@ -175,6 +175,7 @@ export default {
       declaredAppointmentInQuasiJudicialBody: null,
       quasiJudicialSatForThirtyDays: null,
       quasiJudicialSittingDaysDetails: null,
+      skillsAquisitionDetails: null,
       progress: {},
     };
     const data = this.$store.getters['application/data'](defaults);


### PR DESCRIPTION
## What's included?
### Problem:
When a user on the Apply side fills in this section, saves and navigates away when they go back into the Judicial Experience section their Details section has removed the saved copy.

### Solution:
Add missing object property of details in the judicial experience section.

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
1. Go to Judicial Experience section and fill in the details.
2. Click save button and navigate away.
3. Go back to Judicial Experience section and check if the details still exist.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Demo:

https://user-images.githubusercontent.com/79906532/192986890-3326c9b8-858a-4cee-9054-8477dc59ffac.mov

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
