### PR TITLE
#926 Barrister eligibility

### DIFF
--- a/src/components/RepeatableFields/Qualification.vue
+++ b/src/components/RepeatableFields/Qualification.vue
@@ -56,30 +56,30 @@
       />
 
       <RadioGroup
-        :id="qualificationNotComplete"
-        v-model="row.qualificationNotComplete"
+        :id="qualificationComplete"
+        v-model="row.qualificationComplete"
         label="Have you completed pupillage?"
         required
       >
         <RadioItem
-          :value="false"
+          :value="true"
           label="Yes"
         />
         <RadioItem
-          :value="true"
+          :value="false"
           label="No"
         />
       </RadioGroup>
 
       <DateInput
-        v-if="row.qualificationNotComplete === false"
+        v-if="row.qualificationComplete === true"
         :id="qualificationDate"
         v-model="row.date"
         label="When did you complete pupillage?"
         type="month"
         required
       />
-      <div v-else-if="row.qualificationNotComplete === true">
+      <div v-else-if="row.qualificationComplete === false">
         <RadioGroup
           :id="qualificationNotCompleteReason"
           v-model="row.qualificationNotCompleteReason"
@@ -163,8 +163,8 @@ export default {
     details() {
       return `qualification_details_${this.index}`;
     },
-    qualificationNotComplete() {
-      return `qualification_qualificationNotComplete_${this.index}`;
+    qualificationComplete() {
+      return `qualification_qualificationComplete_${this.index}`;
     },
     qualificationNotCompleteReason() {
       return `qualification_not_complete_reason_${this.index}`;

--- a/src/components/RepeatableFields/Qualification.vue
+++ b/src/components/RepeatableFields/Qualification.vue
@@ -87,21 +87,15 @@
           required
         >
           <RadioItem
-            value="Qualified solicitor, qualified lawyer from another jurisdiction, or a legal academic transferred to the Bar"
-            label="Qualified solicitor, qualified lawyer from another jurisdiction, or a legal academic transferred to the Bar"
-          />
-          <RadioItem
-            value="Called to the Bar prior to 1 January 2002"
-            label="Called to the Bar prior to 1 January 2002"
-          />
-          <RadioItem
-            value="Other"
-            label="Other - Please detail why you were exempt from undertaking pupillage by the Bar Standards Board"
+            v-for="option in NOT_COMPLETE_PUPILLAGE_REASONS"
+            :key="option"
+            :value="option"
+            :label="option | lookup"
           />
         </RadioGroup>
 
         <TextareaInput
-          v-if="row.qualificationNotCompleteReason === 'Other'"
+          v-if="row.qualificationNotCompleteReason === NOT_COMPLETE_PUPILLAGE_REASONS.OTHER"
           :id="details"
           v-model="row.details"
           hint="Please provide details how you satisfy the ‘judicial-appointment eligibility condition’, set out in section 50 of the Tribunals, Courts and Enforcement Act 2007"
@@ -128,6 +122,7 @@ import RadioGroup from '@/components/Form/RadioGroup';
 import RadioItem from '@/components/Form/RadioItem';
 import DateInput from '@/components/Form/DateInput';
 import TextareaInput from '@/components/Form/TextareaInput';
+import { NOT_COMPLETE_PUPILLAGE_REASONS } from '@/helpers/constants';
 
 export default {
   name: 'Qualification',
@@ -146,6 +141,11 @@ export default {
       required: true,
       type: Number,
     },
+  },
+  data() {
+    return {
+      NOT_COMPLETE_PUPILLAGE_REASONS,
+    };
   },
   computed: {
     qualificationType() {

--- a/src/components/RepeatableFields/Qualification.vue
+++ b/src/components/RepeatableFields/Qualification.vue
@@ -48,8 +48,8 @@
       v-if="row.type === 'barrister'"
     >
       <DateInput
-        :id="calledToTheBarDate"
-        v-model="row.calledToTheBarDate"
+        :id="calledToBarDate"
+        v-model="row.calledToBarDate"
         label="When were you called to the Bar?"
         type="month"
         required
@@ -154,8 +154,8 @@ export default {
     qualificationLocation() {
       return `qualification_location_${this.index}`;
     },
-    calledToTheBarDate() {
-      return `qualification_calledToTheBar_date_${this.index}`;
+    calledToBarDate() {
+      return `qualification_calledToBar_date_${this.index}`;
     },
     qualificationDate() {
       return `qualification_date_${this.index}`;

--- a/src/components/RepeatableFields/Qualification.vue
+++ b/src/components/RepeatableFields/Qualification.vue
@@ -81,8 +81,8 @@
       />
       <div v-else-if="row.completedPupillage === false">
         <RadioGroup
-          :id="qualificationNotCompleteReason"
-          v-model="row.qualificationNotCompleteReason"
+          :id="notCompletePupillageReason"
+          v-model="row.notCompletePupillageReason"
           label="Why you were exempt from pupillage (we may ask for a copy of your exemption or practicing certificate)?"
           required
         >
@@ -95,7 +95,7 @@
         </RadioGroup>
 
         <TextareaInput
-          v-if="row.qualificationNotCompleteReason === NOT_COMPLETE_PUPILLAGE_REASONS.OTHER"
+          v-if="row.notCompletePupillageReason === NOT_COMPLETE_PUPILLAGE_REASONS.OTHER"
           :id="details"
           v-model="row.details"
           hint="Please provide details how you satisfy the ‘judicial-appointment eligibility condition’, set out in section 50 of the Tribunals, Courts and Enforcement Act 2007"
@@ -166,8 +166,8 @@ export default {
     completedPupillage() {
       return `qualification_completedPupillage_${this.index}`;
     },
-    qualificationNotCompleteReason() {
-      return `qualification_not_complete_reason_${this.index}`;
+    notCompletePupillageReason() {
+      return `qualification_not_complete_pupillage_reason_${this.index}`;
     },
   },
 };

--- a/src/components/RepeatableFields/Qualification.vue
+++ b/src/components/RepeatableFields/Qualification.vue
@@ -43,26 +43,79 @@
         label="Scotland"
       />
     </RadioGroup>
-    <DateInput
-      :id="qualificationDate"
-      v-model="row.date"
-      :label="row.type==='barrister'?'When did you complete pupillage?':'When did you qualify?'"
-      type="month"
-    />
 
     <div
       v-if="row.type === 'barrister'"
     >
-      <Checkbox
+      <DateInput
+        :id="calledToTheBarDate"
+        v-model="row.calledToTheBarDate"
+        label="When were you called to the Bar?"
+        type="month"
+        required
+      />
+
+      <RadioGroup
         :id="qualificationNotComplete"
         v-model="row.qualificationNotComplete"
-        label="I did not complete pupillage"
+        label="Have you completed pupillage?"
+        required
+      >
+        <RadioItem
+          :value="false"
+          label="Yes"
+        />
+        <RadioItem
+          :value="true"
+          label="No"
+        />
+      </RadioGroup>
+
+      <DateInput
+        v-if="row.qualificationNotComplete === false"
+        :id="qualificationDate"
+        v-model="row.date"
+        label="When did you complete pupillage?"
+        type="month"
+        required
       />
-      <TextareaInput
-        v-if="row.qualificationNotComplete"
-        :id="details"
-        v-model="row.details"
-        hint="Please provide some additional information"
+      <div v-else-if="row.qualificationNotComplete === true">
+        <RadioGroup
+          :id="qualificationNotCompleteReason"
+          v-model="row.qualificationNotCompleteReason"
+          label="Why you were exempt from pupillage (we may ask for a copy of your exemption or practicing certificate)?"
+          required
+        >
+          <RadioItem
+            value="Qualified solicitor, qualified lawyer from another jurisdiction, or a legal academic transferred to the Bar"
+            label="Qualified solicitor, qualified lawyer from another jurisdiction, or a legal academic transferred to the Bar"
+          />
+          <RadioItem
+            value="Called to the Bar prior to 1 January 2002"
+            label="Called to the Bar prior to 1 January 2002"
+          />
+          <RadioItem
+            value="Other"
+            label="Other - Please detail why you were exempt from undertaking pupillage by the Bar Standards Board"
+          />
+        </RadioGroup>
+
+        <TextareaInput
+          v-if="row.qualificationNotCompleteReason === 'Other'"
+          :id="details"
+          v-model="row.details"
+          hint="Please provide details how you satisfy the ‘judicial-appointment eligibility condition’, set out in section 50 of the Tribunals, Courts and Enforcement Act 2007"
+          required
+        />
+      </div>
+    </div>
+    
+    <div v-else>
+      <DateInput
+        :id="qualificationDate"
+        v-model="row.date"
+        label="When did you qualify?"
+        type="month"
       />
     </div>
 
@@ -72,7 +125,6 @@
 
 <script>
 import RadioGroup from '@/components/Form/RadioGroup';
-import Checkbox from '@/components/Form/Checkbox';
 import RadioItem from '@/components/Form/RadioItem';
 import DateInput from '@/components/Form/DateInput';
 import TextareaInput from '@/components/Form/TextareaInput';
@@ -81,7 +133,6 @@ export default {
   name: 'Qualification',
   components: {
     RadioGroup,
-    Checkbox,
     RadioItem,
     DateInput,
     TextareaInput,
@@ -103,6 +154,9 @@ export default {
     qualificationLocation() {
       return `qualification_location_${this.index}`;
     },
+    calledToTheBarDate() {
+      return `qualification_calledToTheBar_date_${this.index}`;
+    },
     qualificationDate() {
       return `qualification_date_${this.index}`;
     },
@@ -111,6 +165,9 @@ export default {
     },
     qualificationNotComplete() {
       return `qualification_qualificationNotComplete_${this.index}`;
+    },
+    qualificationNotCompleteReason() {
+      return `qualification_not_complete_reason_${this.index}`;
     },
   },
 };

--- a/src/components/RepeatableFields/Qualification.vue
+++ b/src/components/RepeatableFields/Qualification.vue
@@ -56,8 +56,8 @@
       />
 
       <RadioGroup
-        :id="qualificationComplete"
-        v-model="row.qualificationComplete"
+        :id="completedPupillage"
+        v-model="row.completedPupillage"
         label="Have you completed pupillage?"
         required
       >
@@ -72,14 +72,14 @@
       </RadioGroup>
 
       <DateInput
-        v-if="row.qualificationComplete === true"
+        v-if="row.completedPupillage === true"
         :id="qualificationDate"
         v-model="row.date"
         label="When did you complete pupillage?"
         type="month"
         required
       />
-      <div v-else-if="row.qualificationComplete === false">
+      <div v-else-if="row.completedPupillage === false">
         <RadioGroup
           :id="qualificationNotCompleteReason"
           v-model="row.qualificationNotCompleteReason"
@@ -163,8 +163,8 @@ export default {
     details() {
       return `qualification_details_${this.index}`;
     },
-    qualificationComplete() {
-      return `qualification_qualificationComplete_${this.index}`;
+    completedPupillage() {
+      return `qualification_completedPupillage_${this.index}`;
     },
     qualificationNotCompleteReason() {
       return `qualification_not_complete_reason_${this.index}`;

--- a/src/filters.js
+++ b/src/filters.js
@@ -299,8 +299,8 @@ const lookup = (value) => {
     lookup[ASSESSOR_TYPES.JUDICIAL] = 'Judicial assessor';
     lookup[ASSESSOR_TYPES.PERSONAL] = 'Personal assessor';
 
-    lookup[NOT_COMPLETE_PUPILLAGE_REASONS.OPTION_1] = 'Qualified solicitor, qualified lawyer from another jurisdiction, or a legal academic transferred to the Bar';
-    lookup[NOT_COMPLETE_PUPILLAGE_REASONS.OPTION_2] = 'Called to the Bar prior to 1 January 2002';
+    lookup[NOT_COMPLETE_PUPILLAGE_REASONS.TRANSFERRED] = 'Qualified solicitor, qualified lawyer from another jurisdiction, or a legal academic transferred to the Bar';
+    lookup[NOT_COMPLETE_PUPILLAGE_REASONS.CALLED_PRE_2002] = 'Called to the Bar prior to 1 January 2002';
     lookup[NOT_COMPLETE_PUPILLAGE_REASONS.OTHER] = 'Other - Please detail why you were exempt from undertaking pupillage by the Bar Standards Board';
 
     return lookup[value] || value;

--- a/src/filters.js
+++ b/src/filters.js
@@ -1,4 +1,4 @@
-import { QUALIFYING_TEST, ASSESSOR_TYPES } from '@/helpers/constants';
+import { QUALIFYING_TEST, ASSESSOR_TYPES, NOT_COMPLETE_PUPILLAGE_REASONS } from '@/helpers/constants';
 
 const capitalize = (value) => {
   if (!value) return '';
@@ -298,6 +298,10 @@ const lookup = (value) => {
     lookup[ASSESSOR_TYPES.PROFESSIONAL] = 'Professional assessor';
     lookup[ASSESSOR_TYPES.JUDICIAL] = 'Judicial assessor';
     lookup[ASSESSOR_TYPES.PERSONAL] = 'Personal assessor';
+
+    lookup[NOT_COMPLETE_PUPILLAGE_REASONS.OPTION_1] = 'Qualified solicitor, qualified lawyer from another jurisdiction, or a legal academic transferred to the Bar';
+    lookup[NOT_COMPLETE_PUPILLAGE_REASONS.OPTION_2] = 'Called to the Bar prior to 1 January 2002';
+    lookup[NOT_COMPLETE_PUPILLAGE_REASONS.OTHER] = 'Other - Please detail why you were exempt from undertaking pupillage by the Bar Standards Board';
 
     return lookup[value] || value;
   }

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -56,9 +56,9 @@ const ASSESSOR_TYPES = {
 };
 
 const NOT_COMPLETE_PUPILLAGE_REASONS = {
-  OPTION_1: 'reason-not-completed-pupillage-1',
-  OPTION_2: 'reason-not-completed-pupillage-2',
-  OTHER: 'reason-not-completed-pupillage-other',
+  TRANSFERRED: 'transferred ',
+  CALLED_PRE_2002: 'called-pre-2002',
+  OTHER: 'other',
 };
 
 export {

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -55,6 +55,12 @@ const ASSESSOR_TYPES = {
   PERSONAL: 'personal',
 };
 
+const NOT_COMPLETE_PUPILLAGE_REASONS = {
+  OPTION_1: 'reason-not-completed-pupillage-1',
+  OPTION_2: 'reason-not-completed-pupillage-2',
+  OTHER: 'reason-not-completed-pupillage-other',
+};
+
 export {
   STATUS,
   QUALIFYING_TEST,
@@ -63,5 +69,6 @@ export {
   DEFAULT,
   WELSH_POSTS_CONTACT_MAILBOX,
   WELSH_POSTS_EMAIL_SUBJECT,
-  ASSESSOR_TYPES
+  ASSESSOR_TYPES,
+  NOT_COMPLETE_PUPILLAGE_REASONS
 };

--- a/src/views/Apply/FinalCheck/Qualifications.vue
+++ b/src/views/Apply/FinalCheck/Qualifications.vue
@@ -50,14 +50,14 @@
         <dd class="govuk-summary-list__value">
           <ul class="govuk-list">
             <li>
-              {{ item.qualificationComplete | toYesNo }}
+              {{ item.completedPupillage | toYesNo }}
             </li>
           </ul>
         </dd>
       </div>
 
       <div
-        v-if="item.qualificationComplete && item.date"
+        v-if="item.completedPupillage && item.date"
         class="govuk-summary-list__row"
       >
         <dt
@@ -80,7 +80,7 @@
       </div>
 
       <div
-        v-if="!item.qualificationComplete && item.details"
+        v-if="!item.completedPupillage && item.details"
         class="govuk-summary-list__row"
       >
         <dt class="govuk-summary-list__key">

--- a/src/views/Apply/FinalCheck/Qualifications.vue
+++ b/src/views/Apply/FinalCheck/Qualifications.vue
@@ -28,7 +28,37 @@
       </div>
 
       <div
-        v-if="item.date"
+        v-if="item.type === 'barrister' && item.calledToTheBarDate"
+        class="govuk-summary-list__row"
+      >
+        <dt class="govuk-summary-list__key">
+          Date called to the Bar 
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <ul class="govuk-list">
+            <li> {{ item.calledToTheBarDate | formatDate }}</li>
+          </ul>
+        </dd>
+      </div>
+
+      <div
+        v-if="item.qualificationNotComplete"
+        class="govuk-summary-list__row"
+      >
+        <dt class="govuk-summary-list__key">
+          Completed pupillage
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <ul class="govuk-list">
+            <li>
+              No
+            </li>
+          </ul>
+        </dd>
+      </div>
+
+      <div
+        v-if="!item.qualificationNotComplete && item.date"
         class="govuk-summary-list__row"
       >
         <dt
@@ -51,22 +81,6 @@
       </div>
 
       <div
-        v-if="item.qualificationNotComplete"
-        class="govuk-summary-list__row"
-      >
-        <dt class="govuk-summary-list__key">
-          Completed pupillage
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <ul class="govuk-list">
-            <li>
-              No
-            </li>
-          </ul>
-        </dd>
-      </div>
-
-      <div
         v-if="item.qualificationNotComplete && item.details"
         class="govuk-summary-list__row"
       >
@@ -76,7 +90,9 @@
         <dd class="govuk-summary-list__value">
           <ul class="govuk-list">
             <li>
-              {{ item.details }}
+              {{
+                item.qualificationNotCompleteReason === 'Other' ? item.details : item.qualificationNotCompleteReason
+              }}
             </li>
           </ul>
         </dd>

--- a/src/views/Apply/FinalCheck/Qualifications.vue
+++ b/src/views/Apply/FinalCheck/Qualifications.vue
@@ -28,7 +28,7 @@
       </div>
 
       <div
-        v-if="item.type === 'barrister' && item.calledToTheBarDate"
+        v-if="item.type === 'barrister' && item.calledToBarDate"
         class="govuk-summary-list__row"
       >
         <dt class="govuk-summary-list__key">
@@ -36,7 +36,7 @@
         </dt>
         <dd class="govuk-summary-list__value">
           <ul class="govuk-list">
-            <li> {{ item.calledToTheBarDate | formatDate }}</li>
+            <li> {{ item.calledToBarDate | formatDate }}</li>
           </ul>
         </dd>
       </div>

--- a/src/views/Apply/FinalCheck/Qualifications.vue
+++ b/src/views/Apply/FinalCheck/Qualifications.vue
@@ -42,7 +42,6 @@
       </div>
 
       <div
-        v-if="item.qualificationNotComplete"
         class="govuk-summary-list__row"
       >
         <dt class="govuk-summary-list__key">
@@ -51,14 +50,14 @@
         <dd class="govuk-summary-list__value">
           <ul class="govuk-list">
             <li>
-              No
+              {{ item.qualificationComplete | toYesNo }}
             </li>
           </ul>
         </dd>
       </div>
 
       <div
-        v-if="!item.qualificationNotComplete && item.date"
+        v-if="item.qualificationComplete && item.date"
         class="govuk-summary-list__row"
       >
         <dt
@@ -81,7 +80,7 @@
       </div>
 
       <div
-        v-if="item.qualificationNotComplete && item.details"
+        v-if="!item.qualificationComplete && item.details"
         class="govuk-summary-list__row"
       >
         <dt class="govuk-summary-list__key">
@@ -89,10 +88,11 @@
         </dt>
         <dd class="govuk-summary-list__value">
           <ul class="govuk-list">
-            <li>
-              {{
-                item.qualificationNotCompleteReason === 'Other' ? item.details : item.qualificationNotCompleteReason
-              }}
+            <li v-if="item.qualificationNotCompleteReason === NOT_COMPLETE_PUPILLAGE_REASONS.OTHER">
+              {{ item.details }}
+            </li>
+            <li v-else>
+              {{ item.qualificationNotCompleteReason | lookup }}
             </li>
           </ul>
         </dd>
@@ -102,12 +102,19 @@
 </template>
 
 <script>
+import { NOT_COMPLETE_PUPILLAGE_REASONS } from '@/helpers/constants';
+
 export default {
   props: {
     application: {
       type: Object,
       required: true,
     },
+  },
+  data() {
+    return {
+      NOT_COMPLETE_PUPILLAGE_REASONS,
+    };
   },
 };
 </script>

--- a/src/views/Apply/FinalCheck/Qualifications.vue
+++ b/src/views/Apply/FinalCheck/Qualifications.vue
@@ -88,11 +88,11 @@
         </dt>
         <dd class="govuk-summary-list__value">
           <ul class="govuk-list">
-            <li v-if="item.qualificationNotCompleteReason === NOT_COMPLETE_PUPILLAGE_REASONS.OTHER">
+            <li v-if="item.notCompletePupillageReason === NOT_COMPLETE_PUPILLAGE_REASONS.OTHER">
               {{ item.details }}
             </li>
             <li v-else>
-              {{ item.qualificationNotCompleteReason | lookup }}
+              {{ item.notCompletePupillageReason | lookup }}
             </li>
           </ul>
         </dd>


### PR DESCRIPTION
## What's included?
Modify the flow under the "Relevant qualifications" section when applicants are barristers:

<img width="566" alt="Screenshot 2022-10-05 at 12 44 16" src="https://user-images.githubusercontent.com/79906532/194052792-ee40f627-01d8-4b9c-8f8e-d3f4ba1d315a.png">

Note: this PR is related to [#926 Barrister eligibility](https://github.com/jac-uk/admin/pull/1745) on admin repository.

Note: in this PR will use `qualificationComplete` instead of `qualificationNotComplete` to mark if the pupillage has completed.

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
1. Go to "Relevant qualifications" and select "Barrister".
2. Fill in the date called to the Bar.
3. Select Yes/No when you answer "Have you completed pupillage" question? If Yes is selected, you are able to fill in the date you completed pupillage. If No is selected, you are able to choose the reason or fill in other details. 


## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Demo:

https://user-images.githubusercontent.com/79906532/194055618-5c35b630-7b56-4796-bfc1-2fb83217ce58.mov

---
PREVIEW:DEVELOP
