### PR TITLE
#773 Important language changes: Death of QEII

### DIFF
--- a/src/views/Apply/AccountProfile/EqualityAndDiversitySurvey.vue
+++ b/src/views/Apply/AccountProfile/EqualityAndDiversitySurvey.vue
@@ -37,7 +37,7 @@
         </p>
         <p class="govuk-body-l">
           If you are recommended for an appointment we will also share your information with the Ministry of Justice,
-          Judicial Office and Her Majesty's Courts and Tribunal Service.
+          Judicial Office and His Majesty's Courts and Tribunal Service.
         </p>
 
         <RadioGroup


### PR DESCRIPTION
## What's included?
Following the death of QEII the Digital Platform needs to amend any language referring to QEII, e.g.
- Her Majesty becomes His Majesty
- Queen's Counsel becomes King's Counsel

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Go to `Equality and diversity` under `Account profile` section and check the wording.
```
If you are recommended for an appointment we will also share your information with the Ministry of Justice, Judicial Office and His Majesty's Courts and Tribunal Service.
```

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

---
PREVIEW:DEVELOP
