### PR TITLE
#165 Change of wording for IAs

### DIFF
--- a/src/helpers/Timeline/exerciseTimeline.js
+++ b/src/helpers/Timeline/exerciseTimeline.js
@@ -191,7 +191,7 @@ const exerciseTimeline = (data) => {
         {
           entry: 'Return date for independent assessments',
           date: data.independentAssessmentsReturnDate,
-          dateString: isDate(data.independentAssessmentsReturnDate) ? formatDate(data.independentAssessmentsReturnDate) : null,
+          dateString: isDate(data.independentAssessmentsReturnDate) ? formatDate(data.independentAssessmentsReturnDate, 'hour') : null,
         }
       );
     }

--- a/src/helpers/date.js
+++ b/src/helpers/date.js
@@ -32,9 +32,14 @@ const formatDate = (date, type) => {
   }
 
   const month = date.toLocaleString('en-GB', { month: 'long' });
+  const hour = date.toLocaleString('en-GB', { hour: 'numeric', hour12: true }).toLowerCase();
 
   if (type && type === 'month') {
     return `${month} ${date.getFullYear()}`;
+  }
+
+  if (type && type === 'hour') {
+    return `${hour} on ${date.getDate()} ${month} ${date.getFullYear()}`;
   }
 
   return `${date.getDate()} ${month} ${date.getFullYear()}`;

--- a/tests/unit/helpers/Timeline/exerciseTimeline.spec.js
+++ b/tests/unit/helpers/Timeline/exerciseTimeline.spec.js
@@ -89,7 +89,7 @@ describe('helpers/Form/exerciseTimeline', () => {
             expect(exerciseTimeline(timelineArray)).toEqual([
                 {
                     'date': new Date('1999'),
-                    'dateString': '1 January 1999',
+                    'dateString': '0 am on 1 January 1999',
                     'entry': 'Return date for independent assessments',
                 },
             ]);


### PR DESCRIPTION
## What's included?
Update the wording of "Return date for independent assessments" in the timeline. E.g. `1 pm on 1 October 2022`.

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Go to a vacancy and check the date format of "Return date for independent assessments".

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Screenshot:

<img width="480" alt="apply #165 Change of wording for IAs" src="https://user-images.githubusercontent.com/79906532/197199647-2c7841ce-d506-46bb-b928-dd4a0d672900.png">

---
PREVIEW:DEVELOP
