### PR TITLE
#1751 Stat Con Letter Guidance

### DIFF
--- a/src/views/Vacancy/VacancyDetails.vue
+++ b/src/views/Vacancy/VacancyDetails.vue
@@ -202,6 +202,16 @@
                 :title="file.title"
               />
             </li>
+            <li
+              v-for="file in vacancy.downloads.statutoryConsultationGuidanceLetter"
+              :key="file.file"
+            >
+              <DownloadLink
+                :file-name="file.file"
+                :exercise-id="vacancy.id"
+                :title="file.title"
+              />
+            </li>
           </ul>
         </nav>
       </aside>


### PR DESCRIPTION
## What's included?
Add the "statutory consultation guidance letter" to download list of a vacancy.

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Go to the "Related content" of a vacancy and check if "statutory consultation guidance letter" is able to download.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Demo:

https://user-images.githubusercontent.com/79906532/197239541-c02f87eb-bad6-4008-b3ed-b2a5a632c7d3.mov

---
PREVIEW:DEVELOP
