### PR TITLE
Bugfix: #1760 Character consent confirmation message slanted

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -112,3 +112,10 @@ body {
 .govuk-input:disabled {
   background-color: #ccc;
 }
+
+@media (min-width: 1020px) and (max-width: 1260px) {
+  .govuk-width-container {
+    margin-right: 30px;
+    margin-left: 30px;
+  }
+}

--- a/src/views/Apply/CharacterChecks/FormSubmitted.vue
+++ b/src/views/Apply/CharacterChecks/FormSubmitted.vue
@@ -1,42 +1,40 @@
 <template>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds govuk-!-margin-top-8">
-      <div class="govuk-panel govuk-panel--confirmation">
-        <h1 class="govuk-panel__title">
-          Consent to character checks submitted
-        </h1>
-      </div>
-      <h2 class="govuk-heading-m govuk-!-margin-top-6">
-        What happens next
-      </h2>
-      <p class="govuk-body">
-        This information will be used by the Judicial Appointments Commission to undertake character checks.
-      </p>
-      <p class="govuk-body">
-        We may get in touch to ask for more information. In the meantime refer to the timeline, given in your exercise to understand the next steps ahead.
-      </p>
-      <p class="govuk-body">
-        If your circumstances change after submitting this form that might impact your ability to meet the good character requirements please notify the
-        <a
-          :href="`mailto:${vacancy.exerciseMailbox}?subject=Re: ${vacancy.referenceNumber}`"
-          class="govuk-link"
-        >Selection Exercise Team</a>.
-      </p>
-      <p class="govuk-body">
-        Any personal data collected and processed is in accordance with the <a
-          href="https://judicialappointments.gov.uk/data-protection-freedom-of-information-and-making-requests-for-your-data/"
-          class="govuk-link"
-          target="_blank"
-        >JAC's privacy standards</a>.
-      </p>
-      <p class="govuk-body govuk-!-margin-top-6">
-        <RouterLink
-          :to="{ name: 'applications' }"
-        >
-          Return to your applications
-        </RouterLink>
-      </p>
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-top-8">
+    <div class="govuk-panel govuk-panel--confirmation">
+      <h1 class="govuk-panel__title">
+        Consent to character checks submitted
+      </h1>
     </div>
+    <h2 class="govuk-heading-m govuk-!-margin-top-6">
+      What happens next
+    </h2>
+    <p class="govuk-body">
+      This information will be used by the Judicial Appointments Commission to undertake character checks.
+    </p>
+    <p class="govuk-body">
+      We may get in touch to ask for more information. In the meantime refer to the timeline, given in your exercise to understand the next steps ahead.
+    </p>
+    <p class="govuk-body">
+      If your circumstances change after submitting this form that might impact your ability to meet the good character requirements please notify the
+      <a
+        :href="`mailto:${vacancy.exerciseMailbox}?subject=Re: ${vacancy.referenceNumber}`"
+        class="govuk-link"
+      >Selection Exercise Team</a>.
+    </p>
+    <p class="govuk-body">
+      Any personal data collected and processed is in accordance with the <a
+        href="https://judicialappointments.gov.uk/data-protection-freedom-of-information-and-making-requests-for-your-data/"
+        class="govuk-link"
+        target="_blank"
+      >JAC's privacy standards</a>.
+    </p>
+    <p class="govuk-body govuk-!-margin-top-6">
+      <RouterLink
+        :to="{ name: 'applications' }"
+      >
+        Return to your applications
+      </RouterLink>
+    </p>
   </div>
 </template>
 


### PR DESCRIPTION
## What's included?
Make the confirmation message of character checks submitted form show properly.

Note: the page will align to left side without any spacing when the screen size is between 1020px to 1200px. In this PR the CSS class `govuk-width-container` will be updated to make sure that there are always 30px at the left and right margin in different screen sizes.

<img width="889" alt="Bugfix #1760 Character consent confirmation message slanted_1" src="https://user-images.githubusercontent.com/79906532/198318381-3154e93b-b675-42d1-af83-8a883d6d1f94.png">

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Complete the character check form and check if the confirmation message can be read properly.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Demo:

https://user-images.githubusercontent.com/79906532/199006192-5a729384-0c9b-4702-aa7a-0cf9217e2089.mov

---
PREVIEW:DEVELOP
