### PR TITLE
Bugfix: assessor types not saved properly

### DIFF
--- a/src/views/Apply/Assessments/AssessorsDetails.vue
+++ b/src/views/Apply/Assessments/AssessorsDetails.vue
@@ -209,10 +209,12 @@ export default {
   mixins: [ApplyMixIn],
   data(){
     const defaults = {
+      firstAssessorType: null,
       firstAssessorFullName: null,
       firstAssessorTitle: null,
       firstAssessorEmail: null,
       firstAssessorPhone: null,
+      secondAssessorType: null,
       secondAssessorFullName: null,
       secondAssessorTitle: null,
       secondAssessorEmail: null,


### PR DESCRIPTION
## What's included?
Fix the saved assessor types are not loaded properly in the assessors' details page.

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
1. Go to the assessors' details and select the first assessor and second assessor.
2. Click save button and check if the first assessor and the second assessor are saved properly.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Demo:

https://user-images.githubusercontent.com/79906532/198984556-d411df8b-3ec6-4c0a-9594-e75ce1859b53.mov

---
PREVIEW:DEVELOP
