### PR TITLE
other downloads added back

### DIFF
--- a/src/views/Vacancy/VacancyDetails.vue
+++ b/src/views/Vacancy/VacancyDetails.vue
@@ -212,6 +212,16 @@
                 :title="file.title"
               />
             </li>
+            <li
+              v-for="file in vacancy.downloads.otherDownloads"
+              :key="file.file"
+            >
+              <DownloadLink
+                :file-name="file.file"
+                :exercise-id="vacancy.id"
+                :title="file.title"
+              />
+            </li>
           </ul>
         </nav>
       </aside>


### PR DESCRIPTION
## What's included?
'Other Downloads' were missing from the additional content section of the vacancy details page. 
I have re-added them so that uploaded files can be accessed by candidates. 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
- Upload a document (or multiple) under 'other downloads' [admin side]
- Check the file appears, named correctly and downloadable on the apply side 

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, notes etc.
![Screenshot 2022-11-09 at 17 01 35](https://user-images.githubusercontent.com/44227249/200893898-7f25d9cc-9e57-41d9-ae04-2fdba4b217f1.png)
ADMIN >>>
![image](https://user-images.githubusercontent.com/44227249/200895213-dcc989e1-ab97-4e1c-9c8f-392e4026989c.png)

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
