### PR TITLE
#1853 log in message

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,27 +7,58 @@
   },
   "extends": [
     "eslint:recommended",
-    "plugin:vue/recommended"
+    "plugin:vue/recommended",
   ],
   "rules": {
-    "func-style": ["error", "expression"],
+    "func-style": [
+      "error",
+      "expression"
+    ],
     "prefer-arrow-callback": "error",
+    "comma-dangle": [
+      "error",
+      {
+        "arrays": "always-multiline",
+        "objects": "always-multiline"
+      }
+    ],
+    "semi": "error",
+    "space-infix-ops": "error",
+    "keyword-spacing": "error",
+    "array-bracket-spacing": [
+      "error",
+      "never"
+    ],
+    "object-curly-spacing": [
+      "error",
+      "always"
+    ],
+    "key-spacing": "error",
+    "no-multiple-empty-lines": [
+      "error",
+      {
+        "max": 1
+      }
+    ],
+    "eol-last": [
+      "error",
+      "always"
+    ],
+    "vue/multi-word-component-names": "off",
     "no-var": "error",
     "prefer-const": "error",
     "prefer-spread": "error",
     "prefer-template": "error",
-    "quotes": ["error", "single", {"avoidEscape": true}],
-    "comma-dangle": ["error", {"arrays": "always-multiline", "objects": "always-multiline"}],
-    "semi": "error",
-    "space-infix-ops": "error",
-    "keyword-spacing": "error",
-    "array-bracket-spacing": ["error", "never"],
-    "object-curly-spacing": ["error", "always"],
-    "key-spacing": "error",
-    "no-multiple-empty-lines": ["error", { "max": 1}],
-    "eol-last": ["error", "always"],
+    "quotes": [
+      "error", 
+      "single", 
+      {
+        "avoidEscape": true
+      }
+    ],
     "no-console": 1,
     "vue/component-name-in-template-casing": "error",
+    "vue/no-reserved-component-names": "off",
     "vue/script-indent": ["error", 2],
     "space-before-function-paren": "off",
     "no-prototype-builtins": "off",

--- a/src/components/Page/ChangeEmailMessage.vue
+++ b/src/components/Page/ChangeEmailMessage.vue
@@ -1,0 +1,18 @@
+<template>
+  <div>
+    <br>
+    <br>
+    If you wish to update and/or change your sign in email address please contact us at:
+    <a
+      class="govuk-link"
+      href="mailto:enquiries@judicialappointments.gov.uk"
+    >
+      enquiries@judicialappointments.gov.uk
+    </a>
+  </div>
+</template>
+<script>
+export default {
+  name: 'ChangeEmailMessage',
+};
+</script>

--- a/src/views/ResetPassword.vue
+++ b/src/views/ResetPassword.vue
@@ -43,6 +43,17 @@
             >
               Send the link
             </button>
+            <br>
+            <br>
+            <p class="govuk-body">
+              If you wish to update and or change your sign in email address please contact us at:
+              <a
+                class="govuk-link"
+                href="mailto:enquiries@judicialappointments.gov.uk"
+              >
+                enquiries@judicialappointments.gov.uk
+              </a>
+            </p>
           </div>
         </div>
       </form>

--- a/src/views/ResetPassword.vue
+++ b/src/views/ResetPassword.vue
@@ -43,17 +43,7 @@
             >
               Send the link
             </button>
-            <br>
-            <br>
-            <p class="govuk-body">
-              If you wish to update and or change your sign in email address please contact us at:
-              <a
-                class="govuk-link"
-                href="mailto:enquiries@judicialappointments.gov.uk"
-              >
-                enquiries@judicialappointments.gov.uk
-              </a>
-            </p>
+            <ChangeEmailMessage />
           </div>
         </div>
       </form>
@@ -63,6 +53,7 @@
 
 <script>
 import TextField from '@/components/Form/TextField';
+import ChangeEmailMessage from '@/components/Page/ChangeEmailMessage';
 import { auth } from '@/firebase';
 import { RECAPTCHA_ACTIONS } from '@/helpers/constants';
 
@@ -70,6 +61,7 @@ export default {
   name: 'ResetPassword',
   components: {
     TextField,
+    ChangeEmailMessage,
   },
   data () {
     return {

--- a/src/views/SignIn.vue
+++ b/src/views/SignIn.vue
@@ -68,16 +68,8 @@
             >
               Reset your password
             </RouterLink>
-            <br>
-            <br>
-            If you wish to update and or change your sign in email address please contact us at:
-            <a
-              class="govuk-link"
-              href="mailto:enquiries@judicialappointments.gov.uk"
-            >
-              enquiries@judicialappointments.gov.uk
-            </a>
           </p>
+          <ChangeEmailMessage />
         </div>
       </form>
     </div>
@@ -86,6 +78,7 @@
 
 <script>
 import ErrorSummary from '@/components/Form/ErrorSummary';
+import ChangeEmailMessage from '@/components/Page/ChangeEmailMessage.vue';
 import TextField from '@/components/Form/TextField';
 import { auth } from '@/firebase';
 import { RECAPTCHA_ACTIONS } from '@/helpers/constants';
@@ -95,6 +88,7 @@ export default {
   components: {
     ErrorSummary,
     TextField,
+    ChangeEmailMessage,
   },
   data () {
     return {

--- a/src/views/SignIn.vue
+++ b/src/views/SignIn.vue
@@ -68,7 +68,15 @@
             >
               Reset your password
             </RouterLink>
-            here.
+            <br>
+            <br>
+            If you wish to update and or change your sign in email address please contact us at:
+            <a
+              class="govuk-link"
+              href="mailto:enquiries@judicialappointments.gov.uk"
+            >
+              enquiries@judicialappointments.gov.uk
+            </a>
           </p>
         </div>
       </form>

--- a/src/views/SignUp.vue
+++ b/src/views/SignUp.vue
@@ -106,17 +106,7 @@
           >
             Create Account
           </button>
-          <br>
-          <br>
-          <p class="govuk-body">
-            If you wish to update and or change your sign in email address please contact us at:
-            <a
-              class="govuk-link"
-              href="mailto:enquiries@judicialappointments.gov.uk"
-            >
-              enquiries@judicialappointments.gov.uk
-            </a>
-          </p>
+          <ChangeEmailMessage />
         </div>
       </form>
     </div>
@@ -131,6 +121,7 @@ import ErrorSummary from '@/components/Form/ErrorSummary';
 import TextField from '@/components/Form/TextField';
 import Password from '@/components/Form/Password';
 import DateInput from '@/components/Form/DateInput';
+import ChangeEmailMessage from '@/components/Page/ChangeEmailMessage.vue';
 
 export default {
   name: 'SignUp',
@@ -139,6 +130,7 @@ export default {
     TextField,
     Password,
     DateInput,
+    ChangeEmailMessage,
   },
   extends: Form,
   data () {

--- a/src/views/SignUp.vue
+++ b/src/views/SignUp.vue
@@ -106,6 +106,17 @@
           >
             Create Account
           </button>
+          <br>
+          <br>
+          <p class="govuk-body">
+            If you wish to update and or change your sign in email address please contact us at:
+            <a
+              class="govuk-link"
+              href="mailto:enquiries@judicialappointments.gov.uk"
+            >
+              enquiries@judicialappointments.gov.uk
+            </a>
+          </p>
         </div>
       </form>
     </div>


### PR DESCRIPTION
## What's included?
Message added to `signUp`,`signIn` and `resetPassword` views, informing candidates to contact enquiries if they need help changing account details. 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Visit the `signUp`,`signIn` and `resetPassword` pages and observe the 

> 'If you wish to update and or change your sign in email address please contact us at: enquiries@judicialappointments.gov.uk' 

message at the bottom of the page.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
![image](https://user-images.githubusercontent.com/44227249/213253216-4b13cdcc-c23b-40fd-81e3-b0a42d55b5d0.png)
---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
