### PR TITLE
#953 Additional personal details fields - tooltip

### DIFF
--- a/src/views/Apply/AccountProfile/PersonalDetails.vue
+++ b/src/views/Apply/AccountProfile/PersonalDetails.vue
@@ -53,6 +53,7 @@
           id="previousNames"
           v-model="personalDetails.previousNames"
           label="Previously known name(s)"
+          hint="Have you ever been known by any other name? For example, life events which may have changed your name such as marriages, divorces, hyphenated names."
         />
 
         <TextField

--- a/src/views/Apply/AccountProfile/PersonalDetails.vue
+++ b/src/views/Apply/AccountProfile/PersonalDetails.vue
@@ -52,7 +52,7 @@
         <TextField
           id="previousNames"
           v-model="personalDetails.previousNames"
-          label="Previously known name(s)"
+          label="Previous known name(s)"
           hint="Have you ever been known by any other name? For example, life events which may have changed your name such as marriages, divorces, hyphenated names."
         />
 

--- a/src/views/Apply/CharacterChecks/PersonalInformation.vue
+++ b/src/views/Apply/CharacterChecks/PersonalInformation.vue
@@ -51,6 +51,7 @@
         id="previousNames"
         v-model="personalDetails.previousNames"
         label="Previously known name(s)"
+        hint="Have you ever been known by any other name? For example, life events which may have changed your name such as marriages, divorces, hyphenated names."
       />
 
       <TextField

--- a/src/views/Apply/CharacterChecks/PersonalInformation.vue
+++ b/src/views/Apply/CharacterChecks/PersonalInformation.vue
@@ -50,7 +50,7 @@
       <TextField
         id="previousNames"
         v-model="personalDetails.previousNames"
-        label="Previously known name(s)"
+        label="Previous known name(s)"
         hint="Have you ever been known by any other name? For example, life events which may have changed your name such as marriages, divorces, hyphenated names."
       />
 

--- a/src/views/Apply/CharacterChecks/Review.vue
+++ b/src/views/Apply/CharacterChecks/Review.vue
@@ -108,7 +108,7 @@
         class="govuk-summary-list__row"
       >
         <dt class="govuk-summary-list__key">
-          Previously known name(s)
+          Previous known name(s)
         </dt>
         <dd class="govuk-summary-list__value">
           {{ application.personalDetails.previousNames }}

--- a/src/views/Apply/FinalCheck/PersonalDetails.vue
+++ b/src/views/Apply/FinalCheck/PersonalDetails.vue
@@ -68,7 +68,7 @@
       class="govuk-summary-list__row"
     >
       <dt class="govuk-summary-list__key">
-        Previously known name(s)
+        Previous known name(s)
       </dt>
       <dd class="govuk-summary-list__value">
         {{ application.personalDetails.previousNames }}


### PR DESCRIPTION
## What's included?
Add the text as the tooltip for `Previous known name(s)`:
```
Have you ever been known by any other name? For example, life events which may have changed your name such as marriages, divorces, hyphenated names.
```

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Go to the `Personal details` section and check if the tooltip of the field `Previously known name(s)` displays.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Screenshot:

![Screenshot 2023-02-02 at 10 05 32](https://user-images.githubusercontent.com/79906532/216294969-d699bcea-6a7b-4b99-baf8-1082e0d4b9bf.png)

---
PREVIEW:DEVELOP
