### PR TITLE
Bugfix: #1902 Vacancy Refresh - Fee Paid Tag

### DIFF
--- a/src/views/Vacancies.vue
+++ b/src/views/Vacancies.vue
@@ -212,26 +212,37 @@
                       </div>
 
                       <div
-                        v-if="vacancy.appointmentType == 'salaried' && (isAdvertTypeBasic(vacancy.advertType) || isAdvertTypeFull(vacancy.advertType))"
+                        v-if="(isAdvertTypeBasic(vacancy.advertType) || isAdvertTypeFull(vacancy.advertType))"
                         class="tag"
                       >
-                        <span
-                          class="govuk-!-font-weight-bold tag-text"
-                        >
-                          SALARY:&nbsp;
-                        </span>
-                        <span
-                          v-if="vacancy.salaryGrouping"
-                          class="govuk-!-font-weight-bold tag-text"
-                        >
-                          {{ vacancy.salaryGrouping | lookup }}
-                        </span>
-                        <span
-                          v-if="vacancy.salary"
-                          class="govuk-!-font-weight-bold tag-text"
-                        >
-                          {{ vacancy.salary | formatCurrency }}
-                        </span>
+                        <template v-if="vacancy.appointmentType == 'salaried'">
+                          <span class="govuk-!-font-weight-bold tag-text">
+                            SALARY:&nbsp;
+                          </span>
+                          <span
+                            v-if="vacancy.salaryGrouping"
+                            class="govuk-!-font-weight-bold tag-text"
+                          >
+                            {{ vacancy.salaryGrouping | lookup }}
+                          </span>
+                          <span
+                            v-if="vacancy.salary"
+                            class="govuk-!-font-weight-bold tag-text"
+                          >
+                            {{ vacancy.salary | formatCurrency }}
+                          </span>
+                        </template>
+                        <template v-else-if="vacancy.appointmentType == 'fee-paid'">
+                          <span class="govuk-!-font-weight-bold tag-text">
+                            FEE PAID:&nbsp;
+                          </span>
+                          <span
+                            v-if="vacancy.feePaidFee"
+                            class="govuk-!-font-weight-bold tag-text"
+                          >
+                            {{ vacancy.feePaidFee | formatCurrency }}
+                          </span>
+                        </template>
                       </div>
 
                       <div
@@ -524,8 +535,6 @@ export default {
 
 <style scoped>
 .tag {
-  display: flex;
-  align-items: center;
   padding: 5px 8px 0;
   background: #EEEFEF;
   color: #383F43;

--- a/src/views/Vacancy/VacancyDetails.vue
+++ b/src/views/Vacancy/VacancyDetails.vue
@@ -100,22 +100,32 @@
         <p v-if="vacancy.location && showLocation">
           <span class="govuk-body govuk-!-font-weight-bold">Location:</span> <span class="govuk-body"> {{ vacancy.location }}</span>
         </p>
-        <p v-if="vacancy.appointmentType == 'salaried' && showAppointmentType">
+        <p v-if="showAppointmentType">
           <span class="govuk-body govuk-!-font-weight-bold">
             Salary/Fee:
           </span>
-          <span
-            v-if="vacancy.salaryGrouping"
-            class="govuk-body"
-          >
-            {{ vacancy.salaryGrouping | lookup }}
-          </span>
-          <span
-            v-if="vacancy.salary"
-            class="govuk-body"
-          >
-            {{ vacancy.salary | formatCurrency }}
-          </span>
+          <template v-if="vacancy.appointmentType == 'salaried'">
+            <span
+              v-if="vacancy.salaryGrouping"
+              class="govuk-body"
+            >
+              {{ vacancy.salaryGrouping | lookup }}
+            </span>
+            <span
+              v-if="vacancy.salary"
+              class="govuk-body"
+            >
+              {{ vacancy.salary | formatCurrency }}
+            </span>
+          </template>
+          <template v-else-if="vacancy.appointmentType == 'fee-paid'">
+            <span
+              v-if="vacancy.feePaidFee"
+              class="govuk-body"
+            >
+              {{ vacancy.feePaidFee | formatCurrency }}
+            </span>
+          </template>
         </p>
         <p
           v-if="vacancy.exerciseMailbox"


### PR DESCRIPTION
## What's included?
Add Fee Paid Tag to show the fee for those exercises which are fee paid

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
1. Go to the Vacancies page and check if the `fee paid` tag shows correctly.
2. Go to the Vacancy details page and check if the `fee paid` shows correctly.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context

Vacancies:

<img width="503" alt="Screenshot 2023-02-17 at 10 45 09" src="https://user-images.githubusercontent.com/79906532/219627121-574543bf-be64-4cf0-9c58-90673a690525.png">

Vacancy details:

<img width="462" alt="Screenshot 2023-02-17 at 10 45 22" src="https://user-images.githubusercontent.com/79906532/219627201-581455c8-1160-4aa4-afe1-03db00295d0d.png">

---
PREVIEW:DEVELOP
