### PR TITLE
Admin#1914 Hardcode Exercise 0149 - Exclude Welsh Applications

### DIFF
--- a/src/store/vacancy.js
+++ b/src/store/vacancy.js
@@ -46,8 +46,9 @@ export default {
       return new Date(closeDate);
     },
     enableApplyInWelsh: (state) => {
-      // exclude exercise 155 on production
-      return state.record ? state.record.welshPosts && state.record.referenceNumber !== 'JAC00155' : false;
+      // exclude some exercises on production
+      const exclusiveReferenceNumbers = ['JAC00155', 'JAC00149'];
+      return state.record ? state.record.welshPosts && !exclusiveReferenceNumbers.includes(state.record.referenceNumber) : false;
     },
   },
 };


### PR DESCRIPTION
## What's included?
Exclude exercise 0149 on production from applying in Welsh.

Closes [Hardcode Exercise 0149 - Exclude Welsh Applications](https://github.com/jac-uk/admin/issues/1914).

## Who should test?
✅ Product owner
✅ Developers

## How to test?
Go to the preview URL on production and check if there is no `Apply in Welsh` button on exercise 0149.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, notes etc.

---
PREVIEW:PRODUCTION
