### PR TITLE
remove line on IA page

### DIFF
--- a/src/assets/welsh.json
+++ b/src/assets/welsh.json
@@ -417,7 +417,6 @@
   "You can set out here why you think you should still be considered for this role. The JAC will consider it when assessing your eligibility for this role.": "Nodwch yma pam rydych chi’n meddwl y dylech chi gael eich ystyried ar gyfer y swydd hon beth bynnag. Bydd y Comisiwn Penodiadau Barnwrol yn ei ystyried wrth asesu eich cymhwysedd ar gyfer y swydd hon.",
   "Give independent assessors details": "Nodwch fanylion yr aseswyr annibynnol",
   "Sometimes called 'referees', your independent assessors will give us their opinion on your suitability for this role.": "A hwythau'n cael eu galw'n ‘ganolwyr’ weithiau, bydd eich aseswyr annibynnol yn rhoi eu barn i ni am eich addasrwydd ar gyfer y rôl hon.",
-  "We'll only contact them if you pass the first round of shortlisting.": "Dim ond os byddwch yn pasio rhan gyntaf y broses llunio rhestr fer y byddwn yn cysylltu â nhw.",
   "You should read the": "Dylech ddarllen y",
   "guidance on choosing independent assessors": "canllawiau ar ddewis aseswyr annibynnol",
   "before making your nominations.": "cyn gwneud eich enwebiadau.",

--- a/src/views/Apply/Assessments/AssessorsDetails.vue
+++ b/src/views/Apply/Assessments/AssessorsDetails.vue
@@ -18,10 +18,6 @@
         </p>
 
         <p class="govuk-body-l">
-          We'll only contact them if you pass the first round of shortlisting.
-        </p>
-
-        <p class="govuk-body-l">
           You should read the
           <a
             class="govuk-link info-link--independend-assessor--guidance-on-choosing-independent-assessor"
@@ -68,15 +64,15 @@
 
             <p>If you are unable to provide one of the above, consider another judge who has first-hand knowledge of your work. If you are unable to provide any judicial assessor, please contact us giving your reasons writing.</p>
             <p>If you are applying for a <strong>non-legal role</strong> you should choose assessors who know you well and who can give clear examples of your abilities.</p>
-            
+
             <p>A <u>personal assessor</u> could be:</p>
             <ul>
               <li>a former colleague, manager or client who is familiar with the way you work</li>
               <li>someone for whom you do voluntary work</li>
             </ul>
-        
+
             <p>If you have been on maternity leave or a career break, there is no time limit on how recently you have worked with your assessor, although where possible within the last 2 years is recommended so they can provide recent examples.</p>
-            
+
             <p>Do not nominate:</p>
             <ul>
               <li>another individual who is applying for a role in the same exercise</li>


### PR DESCRIPTION
## What's included?
"We'll only contact them if you pass the first round of shortlisting" removed on the IA page and in the welsh translation json.

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
- Visit IA page.
- Check wording isnt present

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, notes etc.

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
