### PR TITLE
IA numbers in review

### DIFF
--- a/src/views/Apply/FinalCheck/Review.vue
+++ b/src/views/Apply/FinalCheck/Review.vue
@@ -1003,8 +1003,6 @@
       </button>
     </form>
   </div>
-  </form>
-  </div>
 </template>
 
 <script>

--- a/src/views/Apply/FinalCheck/Review.vue
+++ b/src/views/Apply/FinalCheck/Review.vue
@@ -580,6 +580,15 @@
                 </dd>
               </div>
 
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                  Phone
+                </dt>
+                <dd class="govuk-summary-list__value">
+                  {{ application.firstAssessorPhone }}
+                </dd>
+              </div>
+
               <hr class="govuk-section-break govuk-section-break--xl">
 
               <div class="govuk-summary-list__row">
@@ -616,374 +625,385 @@
                   {{ application.secondAssessorEmail }}
                 </dd>
               </div>
-            </dl>
-          </div>
 
-          <div v-if="applicationParts.selfAssessmentCompetencies">
-            <div class="govuk-!-margin-top-9">
-              <h2
-                class="govuk-heading-l"
-                style="display:inline-block;"
-              >
-                Self assessment with competencies
-              </h2>
-              <RouterLink
-                v-if="canEdit && currentApplicationParts.selfAssessmentCompetencies"
-                class="govuk-link govuk-body-m change-link"
-                style="display:inline-block;"
-                :to="{name: 'self-assessment-competencies'}"
-              >
-                Change
-              </RouterLink>
-            </div>
-            <dl class="govuk-summary-list">
-              <div
-                class="govuk-summary-list__row"
-              >
+              <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">
-                  Uploaded self assessment with competencies
+                  Phone
                 </dt>
                 <dd class="govuk-summary-list__value">
-                  <div v-if="application.uploadedSelfAssessment">
-                    <DownloadLink
-                      :file-name="application.uploadedSelfAssessment"
-                      :exercise-id="vacancy.id"
-                      :user-id="application.userId"
-                      :title="application.uploadedSelfAssessment"
-                    />
-                  </div>
-                  <span v-else>Not yet received</span>
+                  {{ application.secondAssessorPhone }}
                 </dd>
               </div>
             </dl>
           </div>
+        </div>
 
-          <div v-if="applicationParts.leadershipJudgeDetails">
-            <div class="govuk-!-margin-top-9">
-              <h2
-                class="govuk-heading-l"
-                style="display:inline-block;"
-              >
-                Leadership Judge details
-              </h2>
-              <RouterLink
-                v-if="canEdit && currentApplicationParts.leadershipJudgeDetails"
-                class="govuk-link govuk-body-m change-link"
-                style="display:inline-block;"
-                :to="{name: 'leadership-judge-details'}"
-              >
-                Change
-              </RouterLink>
-            </div>
-            <dl
-              v-if="application.leadershipJudgeDetails"
-              class="govuk-summary-list"
-            >
-              <div class="govuk-summary-list__row">
-                <dt class="govuk-summary-list__key">
-                  Full name
-                </dt>
-                <dd class="govuk-summary-list__value">
-                  {{ application.leadershipJudgeDetails.fullName }}
-                </dd>
-              </div>
-
-              <div class="govuk-summary-list__row">
-                <dt class="govuk-summary-list__key">
-                  Title or position
-                </dt>
-                <dd class="govuk-summary-list__value">
-                  {{ application.leadershipJudgeDetails.title }}
-                </dd>
-              </div>
-
-              <div class="govuk-summary-list__row">
-                <dt class="govuk-summary-list__key">
-                  Email
-                </dt>
-                <dd class="govuk-summary-list__value">
-                  {{ application.leadershipJudgeDetails.email }}
-                </dd>
-              </div>
-
-              <div class="govuk-summary-list__row">
-                <dt class="govuk-summary-list__key">
-                  Telephone
-                </dt>
-                <dd class="govuk-summary-list__value">
-                  {{ application.leadershipJudgeDetails.phone }}
-                </dd>
-              </div>
-            </dl>
-          </div>
-
-          <div v-if="applicationParts.additionalInfo">
-            <div
-              class="govuk-!-margin-top-9"
-            >
-              <h2
-                class="govuk-heading-l"
-                style="display:inline-block;"
-              >
-                Additional Information
-              </h2>
-              <RouterLink
-                v-if="canEdit && currentApplicationParts.additionalInfo"
-                class="govuk-link govuk-body-m change-link"
-                style="display:inline-block;"
-                :to="{name: 'additional-information'}"
-              >
-                Change
-              </RouterLink>
-            </div>
-
-            <dl
-              class="govuk-summary-list govuk-!-margin-bottom-8"
-            >
-              <div class="govuk-summary-list__row">
-                <dt class="govuk-summary-list__key">
-                  How did you hear about the vacancy?
-                </dt>
-                <dd class="govuk-summary-list__value">
-                  <ul
-                    v-if="application.additionalInfo && application.additionalInfo.listedSources"
-                    class="govuk-list"
-                  >
-                    <li
-                      v-for="(item, index) in application.additionalInfo.listedSources"
-                      :key="index"
-                    >
-                      <p
-                        v-if="item == 'other'"
-                        class="govuk-body govuk-!-margin-bottom-0"
-                      >
-                        <span class="govuk-caption-m">{{ item | lookup }}</span>
-                        {{ application.additionalInfo.otherSources }}
-                      </p>
-                      <span v-else>{{ item | lookup }}</span>
-                    </li>
-                  </ul>
-                  <div
-                    v-else
-                  >
-                    <span
-                      class="govuk-body"
-                    >
-                      No information provided
-                    </span>
-                  </div>
-                </dd>
-              </div>
-            </dl>
-          </div>
-
-          <div
-            v-if="hasStatementOfEligibility"
-            class="govuk-!-margin-top-9"
-          >
-            <h2 class="govuk-heading-l">
-              Additional Selection Criteria
-            </h2>
-
-            <dl class="govuk-summary-list">
-              <div
-                v-for="(item, index) in application.selectionCriteriaAnswers"
-                :key="index"
-                class="govuk-summary-list__row"
-              >
-                <dt class="govuk-summary-list__key">
-                  {{ vacancy.selectionCriteria[index].title }}
-                </dt>
-                <dd class="govuk-summary-list__value">
-                  <span v-if="item.answer">
-                    {{ item.answerDetails }}
-                  </span>
-                  <span v-else>I do not meet this requirement</span>
-                </dd>
-              </div>
-            </dl>
-          </div>
-
-          <div
-            v-if="applicationParts.statementOfSuitability"
-            id="assessments-heading"
-            class="govuk-!-margin-top-9"
-          >
+        <div v-if="applicationParts.selfAssessmentCompetencies">
+          <div class="govuk-!-margin-top-9">
             <h2
               class="govuk-heading-l"
               style="display:inline-block;"
             >
-              Statement of suitability
-            </h2>
-
-            <RouterLink
-              v-if="canEdit && currentApplicationParts.statementOfSuitability"
-              class="govuk-link govuk-body-m change-link"
-              style="display:inline-block;"
-              :to="{name: 'statement-of-suitability'}"
-            >
-              Change
-            </RouterLink>
-
-            <dl class="govuk-summary-list">
-              <div
-                class="govuk-summary-list__row"
-              >
-                <dt class="govuk-summary-list__key">
-                  Uploaded statement of suitability
-                </dt>
-                <dd class="govuk-summary-list__value">
-                  <div v-if="application.uploadedSuitabilityStatement">
-                    <DownloadLink
-                      :file-name="application.uploadedSuitabilityStatement"
-                      :exercise-id="vacancy.id"
-                      :user-id="application.userId"
-                      :title="application.uploadedSuitabilityStatement"
-                    />
-                  </div>
-                  <span v-else>Not yet received</span>
-                </dd>
-              </div>
-            </dl>
-          </div>
-
-          <div
-            v-if="applicationParts.selfAssessment"
-            id="self-assessment-heading"
-            class="govuk-!-margin-top-9"
-          >
-            <h2
-              class="govuk-heading-l"
-              style="display:inline-block;"
-            >
-              Self assessment competencies
+              Self assessment with competencies
             </h2>
             <RouterLink
-              v-if="canEdit && currentApplicationParts.selfAssessment"
+              v-if="canEdit && currentApplicationParts.selfAssessmentCompetencies"
               class="govuk-link govuk-body-m change-link"
               style="display:inline-block;"
               :to="{name: 'self-assessment-competencies'}"
             >
               Change
             </RouterLink>
-
-            <dl class="govuk-summary-list">
-              <div
-                class="govuk-summary-list__row"
-              >
-                <dt class="govuk-summary-list__key">
-                  Uploaded finished self assessment
-                </dt>
-                <dd class="govuk-summary-list__value">
-                  <div v-if="application.uploadedSelfAssessment">
-                    <DownloadLink
-                      :file-name="application.uploadedSelfAssessment"
-                      :exercise-id="vacancy.id"
-                      :user-id="application.userId"
-                      :title="application.uploadedSelfAssessment"
-                    />
-                  </div>
-                  <span v-else>Not yet received</span>
-                </dd>
-              </div>
-            </dl>
           </div>
-
-          <div
-            v-if="applicationParts.cv"
-            id="cv-heading"
-            class="govuk-!-margin-top-9"
-          >
-            <h2
-              class="govuk-heading-l"
-              style="display:inline-block;"
+          <dl class="govuk-summary-list">
+            <div
+              class="govuk-summary-list__row"
             >
-              Curriculum vitae (CV)
-            </h2>
-            <RouterLink
-              v-if="canEdit && currentApplicationParts.cv"
-              class="govuk-link govuk-body-m change-link"
-              style="display:inline-block;"
-              :to="{name: 'cv'}"
-            >
-              Change
-            </RouterLink>
-
-            <dl class="govuk-summary-list">
-              <div
-                class="govuk-summary-list__row"
-              >
-                <dt class="govuk-summary-list__key">
-                  Uploaded CV
-                </dt>
-                <dd class="govuk-summary-list__value">
-                  <div v-if="application.uploadedCV">
-                    <DownloadLink
-                      :file-name="application.uploadedCV"
-                      :exercise-id="vacancy.id"
-                      :user-id="application.userId"
-                      :title="application.uploadedCV"
-                    />
-                  </div>
-                  <span v-else>Not yet received</span>
-                </dd>
-              </div>
-            </dl>
-          </div>
-
-          <div
-            v-if="applicationParts.coveringLetter"
-            id="covering-letter-heading"
-            class="govuk-!-margin-top-9"
-          >
-            <h2
-              class="govuk-heading-l"
-              style="display:inline-block;"
-            >
-              Covering Letter
-            </h2>
-            <RouterLink
-              v-if="canEdit && currentApplicationParts.coveringLetter"
-              class="govuk-link govuk-body-m change-link"
-              style="display:inline-block;"
-              :to="{name: 'covering-letter'}"
-            >
-              Change
-            </RouterLink>
-
-            <dl class="govuk-summary-list">
-              <div
-                class="govuk-summary-list__row"
-              >
-                <dt class="govuk-summary-list__key">
-                  Uploaded Covering Letter
-                </dt>
-                <dd class="govuk-summary-list__value">
-                  <div v-if="application.uploadedCoveringLetter">
-                    <DownloadLink
-                      :file-name="application.uploadedCoveringLetter"
-                      :exercise-id="vacancy.id"
-                      :user-id="application.userId"
-                      :title="application.uploadedCoveringLetter"
-                    />
-                  </div>
-                  <span v-else>Not yet received</span>
-                </dd>
-              </div>
-            </dl>
-          </div>
+              <dt class="govuk-summary-list__key">
+                Uploaded self assessment with competencies
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <div v-if="application.uploadedSelfAssessment">
+                  <DownloadLink
+                    :file-name="application.uploadedSelfAssessment"
+                    :exercise-id="vacancy.id"
+                    :user-id="application.userId"
+                    :title="application.uploadedSelfAssessment"
+                  />
+                </div>
+                <span v-else>Not yet received</span>
+              </dd>
+            </div>
+          </dl>
         </div>
-        <!-- END download-as-pdf-div -->
 
-        <button
-          v-if="!isVacancyClosed"
-          :disabled="!canApply"
-          class="govuk-button govuk-!-margin-top-8"
+        <div v-if="applicationParts.leadershipJudgeDetails">
+          <div class="govuk-!-margin-top-9">
+            <h2
+              class="govuk-heading-l"
+              style="display:inline-block;"
+            >
+              Leadership Judge details
+            </h2>
+            <RouterLink
+              v-if="canEdit && currentApplicationParts.leadershipJudgeDetails"
+              class="govuk-link govuk-body-m change-link"
+              style="display:inline-block;"
+              :to="{name: 'leadership-judge-details'}"
+            >
+              Change
+            </RouterLink>
+          </div>
+          <dl
+            v-if="application.leadershipJudgeDetails"
+            class="govuk-summary-list"
+          >
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Full name
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ application.leadershipJudgeDetails.fullName }}
+              </dd>
+            </div>
+
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Title or position
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ application.leadershipJudgeDetails.title }}
+              </dd>
+            </div>
+
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Email
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ application.leadershipJudgeDetails.email }}
+              </dd>
+            </div>
+
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Telephone
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ application.leadershipJudgeDetails.phone }}
+              </dd>
+            </div>
+          </dl>
+        </div>
+
+        <div v-if="applicationParts.additionalInfo">
+          <div
+            class="govuk-!-margin-top-9"
+          >
+            <h2
+              class="govuk-heading-l"
+              style="display:inline-block;"
+            >
+              Additional Information
+            </h2>
+            <RouterLink
+              v-if="canEdit && currentApplicationParts.additionalInfo"
+              class="govuk-link govuk-body-m change-link"
+              style="display:inline-block;"
+              :to="{name: 'additional-information'}"
+            >
+              Change
+            </RouterLink>
+          </div>
+
+          <dl
+            class="govuk-summary-list govuk-!-margin-bottom-8"
+          >
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                How did you hear about the vacancy?
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <ul
+                  v-if="application.additionalInfo && application.additionalInfo.listedSources"
+                  class="govuk-list"
+                >
+                  <li
+                    v-for="(item, index) in application.additionalInfo.listedSources"
+                    :key="index"
+                  >
+                    <p
+                      v-if="item == 'other'"
+                      class="govuk-body govuk-!-margin-bottom-0"
+                    >
+                      <span class="govuk-caption-m">{{ item | lookup }}</span>
+                      {{ application.additionalInfo.otherSources }}
+                    </p>
+                    <span v-else>{{ item | lookup }}</span>
+                  </li>
+                </ul>
+                <div
+                  v-else
+                >
+                  <span
+                    class="govuk-body"
+                  >
+                    No information provided
+                  </span>
+                </div>
+              </dd>
+            </div>
+          </dl>
+        </div>
+
+        <div
+          v-if="hasStatementOfEligibility"
+          class="govuk-!-margin-top-9"
         >
-          Send application
-        </button>
+          <h2 class="govuk-heading-l">
+            Additional Selection Criteria
+          </h2>
+
+          <dl class="govuk-summary-list">
+            <div
+              v-for="(item, index) in application.selectionCriteriaAnswers"
+              :key="index"
+              class="govuk-summary-list__row"
+            >
+              <dt class="govuk-summary-list__key">
+                {{ vacancy.selectionCriteria[index].title }}
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <span v-if="item.answer">
+                  {{ item.answerDetails }}
+                </span>
+                <span v-else>I do not meet this requirement</span>
+              </dd>
+            </div>
+          </dl>
+        </div>
+
+        <div
+          v-if="applicationParts.statementOfSuitability"
+          id="assessments-heading"
+          class="govuk-!-margin-top-9"
+        >
+          <h2
+            class="govuk-heading-l"
+            style="display:inline-block;"
+          >
+            Statement of suitability
+          </h2>
+
+          <RouterLink
+            v-if="canEdit && currentApplicationParts.statementOfSuitability"
+            class="govuk-link govuk-body-m change-link"
+            style="display:inline-block;"
+            :to="{name: 'statement-of-suitability'}"
+          >
+            Change
+          </RouterLink>
+
+          <dl class="govuk-summary-list">
+            <div
+              class="govuk-summary-list__row"
+            >
+              <dt class="govuk-summary-list__key">
+                Uploaded statement of suitability
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <div v-if="application.uploadedSuitabilityStatement">
+                  <DownloadLink
+                    :file-name="application.uploadedSuitabilityStatement"
+                    :exercise-id="vacancy.id"
+                    :user-id="application.userId"
+                    :title="application.uploadedSuitabilityStatement"
+                  />
+                </div>
+                <span v-else>Not yet received</span>
+              </dd>
+            </div>
+          </dl>
+        </div>
+
+        <div
+          v-if="applicationParts.selfAssessment"
+          id="self-assessment-heading"
+          class="govuk-!-margin-top-9"
+        >
+          <h2
+            class="govuk-heading-l"
+            style="display:inline-block;"
+          >
+            Self assessment competencies
+          </h2>
+          <RouterLink
+            v-if="canEdit && currentApplicationParts.selfAssessment"
+            class="govuk-link govuk-body-m change-link"
+            style="display:inline-block;"
+            :to="{name: 'self-assessment-competencies'}"
+          >
+            Change
+          </RouterLink>
+
+          <dl class="govuk-summary-list">
+            <div
+              class="govuk-summary-list__row"
+            >
+              <dt class="govuk-summary-list__key">
+                Uploaded finished self assessment
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <div v-if="application.uploadedSelfAssessment">
+                  <DownloadLink
+                    :file-name="application.uploadedSelfAssessment"
+                    :exercise-id="vacancy.id"
+                    :user-id="application.userId"
+                    :title="application.uploadedSelfAssessment"
+                  />
+                </div>
+                <span v-else>Not yet received</span>
+              </dd>
+            </div>
+          </dl>
+        </div>
+
+        <div
+          v-if="applicationParts.cv"
+          id="cv-heading"
+          class="govuk-!-margin-top-9"
+        >
+          <h2
+            class="govuk-heading-l"
+            style="display:inline-block;"
+          >
+            Curriculum vitae (CV)
+          </h2>
+          <RouterLink
+            v-if="canEdit && currentApplicationParts.cv"
+            class="govuk-link govuk-body-m change-link"
+            style="display:inline-block;"
+            :to="{name: 'cv'}"
+          >
+            Change
+          </RouterLink>
+
+          <dl class="govuk-summary-list">
+            <div
+              class="govuk-summary-list__row"
+            >
+              <dt class="govuk-summary-list__key">
+                Uploaded CV
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <div v-if="application.uploadedCV">
+                  <DownloadLink
+                    :file-name="application.uploadedCV"
+                    :exercise-id="vacancy.id"
+                    :user-id="application.userId"
+                    :title="application.uploadedCV"
+                  />
+                </div>
+                <span v-else>Not yet received</span>
+              </dd>
+            </div>
+          </dl>
+        </div>
+
+        <div
+          v-if="applicationParts.coveringLetter"
+          id="covering-letter-heading"
+          class="govuk-!-margin-top-9"
+        >
+          <h2
+            class="govuk-heading-l"
+            style="display:inline-block;"
+          >
+            Covering Letter
+          </h2>
+          <RouterLink
+            v-if="canEdit && currentApplicationParts.coveringLetter"
+            class="govuk-link govuk-body-m change-link"
+            style="display:inline-block;"
+            :to="{name: 'covering-letter'}"
+          >
+            Change
+          </RouterLink>
+
+          <dl class="govuk-summary-list">
+            <div
+              class="govuk-summary-list__row"
+            >
+              <dt class="govuk-summary-list__key">
+                Uploaded Covering Letter
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <div v-if="application.uploadedCoveringLetter">
+                  <DownloadLink
+                    :file-name="application.uploadedCoveringLetter"
+                    :exercise-id="vacancy.id"
+                    :user-id="application.userId"
+                    :title="application.uploadedCoveringLetter"
+                  />
+                </div>
+                <span v-else>Not yet received</span>
+              </dd>
+            </div>
+          </dl>
+        </div>
       </div>
+      <!-- END download-as-pdf-div -->
+
+      <button
+        v-if="!isVacancyClosed"
+        :disabled="!canApply"
+        class="govuk-button govuk-!-margin-top-8"
+      >
+        Send application
+      </button>
     </form>
+  </div>
+  </form>
   </div>
 </template>
 


### PR DESCRIPTION
## What's included?
Application collects numbers for IA's but doesn't display them on the review page. 
until now.

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
- Ensure the fields appear on the review page.
I suggest any testers find a submitted application of theirs through the admin interface and set this back to draft then navigate to apply to get to the review page. 

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
