### PR TITLE
Other qualfications

### DIFF
--- a/src/components/RepeatableFields/Qualification.vue
+++ b/src/components/RepeatableFields/Qualification.vue
@@ -22,6 +22,12 @@
         value="solicitor"
         label="Solicitor"
       />
+
+      <RadioItem
+        v-if="vacancy.qualifications.includes('other') && vacancy.otherQualifications"
+        :value="vacancy.otherQualifications"
+        :label="vacancy.otherQualifications"
+      />
     </RadioGroup>
 
     <RadioGroup
@@ -103,7 +109,7 @@
         />
       </div>
     </div>
-    
+
     <div v-else>
       <DateInput
         :id="qualificationDate"
@@ -123,6 +129,7 @@ import RadioItem from '@/components/Form/RadioItem';
 import DateInput from '@/components/Form/DateInput';
 import TextareaInput from '@/components/Form/TextareaInput';
 import { NOT_COMPLETE_PUPILLAGE_REASONS } from '@/helpers/constants';
+import ApplyMixIn from '@/views/Apply/ApplyMixIn';
 
 export default {
   name: 'Qualification',
@@ -132,6 +139,7 @@ export default {
     DateInput,
     TextareaInput,
   },
+  mixins: [ApplyMixIn],
   props: {
     row: {
       required: true,

--- a/src/components/RepeatableFields/Qualification.vue
+++ b/src/components/RepeatableFields/Qualification.vue
@@ -178,8 +178,5 @@ export default {
       return `qualification_not_complete_pupillage_reason_${this.index}`;
     },
   },
-  created() {
-    console.log(this.vacancy);
-  },
 };
 </script>

--- a/src/components/RepeatableFields/Qualification.vue
+++ b/src/components/RepeatableFields/Qualification.vue
@@ -178,5 +178,8 @@ export default {
       return `qualification_not_complete_pupillage_reason_${this.index}`;
     },
   },
+  created() {
+    console.log(this.vacancy);
+  },
 };
 </script>

--- a/tests/unit/helpers.js
+++ b/tests/unit/helpers.js
@@ -29,6 +29,8 @@ const mocks = {
           jurisdictionQuestionType: '',
           shortlistingOutcomeDate: '',
           additionalWorkingPreferences: [],
+          qualifications: [],
+          otherQualifications: '',
         },
       },
       candidate: {


### PR DESCRIPTION
## What's included?
Custom 'Other' qualifications from admin were not pulling thru and showing on apply.
They now show thanks to some help form the applymixin

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
- Using a legal exercise on admin
- Configure a custom 'other' qualification
- Apply and ensure you can select this qualification under eligibility

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, notes etc.

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
