### PR TITLE
Admin#1900 Avoid email address with apostrophe

### DIFF
--- a/src/components/Form/FormField.vue
+++ b/src/components/Form/FormField.vue
@@ -58,7 +58,7 @@ export default {
       checkErrors: false,
       regex: {
         // eslint-disable-next-line
-        email: /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/, // ref: https://emailregex.com/
+        email: /^(([^<>()\[\]\\.,;:’\s@"]+(\.[^<>()\[\]\\.,;:’\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/, // ref: https://emailregex.com/
         // match UK numbers and E.164 format (ref: https://regexpattern.com/phone-number/#uk)
         tel: /(^(((\+44\s?\d{4}|\(?0\d{4}\)?)\s?\d{3}\s?\d{3})|((\+44\s?\d{3}|\(?0\d{3}\)?)\s?\d{3}\s?\d{4})|((\+44\s?\d{2}|\(?0\d{2}\)?)\s?\d{4}\s?\d{4}))(\s?#(\d{4}|\d{3}))?$)|(^\+?[1-9]\d{1,14}$)/,
         nino: /^(?!BG|GB|NK|KN|TN|NT|ZZ)[A-CEGHJ-PR-TW-Z][A-CEGHJ-NPR-TW-Z](?:\s?\d){6}\s?[A-D]$/i,


### PR DESCRIPTION
## What's included?
Since GOV UK Notify API endpoint does not support email addresses with apostrophe (’), in this PR the email regex will be updated to prevent users from providing email addresses with apostrophe (’).

Closes [admin #1900](https://github.com/jac-uk/admin/issues/1900)

Note: should we add some hint message to let users know that a email with apostrophes is not supported?

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Go to the following pages and check if you cant not type an email address with apostrophes:
- Create an account
- Your profile
- Apply for the role 
    - Account profile - Personal details
    - Assessments - Independent assessors' details

## Risk - how likely is this to impact other areas?
🟠 Medium risk - this does change code that is shared with other areas

## Additional context
Include screen grabs, notes etc.

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
