### PR TITLE
Admin#1976 Vacancy details in welsh

### DIFF
--- a/src/views/Vacancy/VacancyDetails.vue
+++ b/src/views/Vacancy/VacancyDetails.vue
@@ -47,13 +47,33 @@
     </div>
 
     <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-9">
+      <div
+        v-if="enableApplyInWelsh"
+        style="display: flex; justify-content: flex-end; gap: 10px;"
+      >
+        <button
+          v-if="language === LANGUAGES.WELSH"
+          class="govuk-button govuk-button--success"
+          @click="() => setLanguage(LANGUAGES.ENGLISH)"
+        >
+          {{ LANGUAGES.ENGLISH | lookup }}
+        </button>
+        <button
+          v-else-if="language === LANGUAGES.ENGLISH"
+          class="govuk-button govuk-button--success"
+          @click="() => setLanguage(LANGUAGES.WELSH)"
+        >
+          {{ LANGUAGES.WELSH | lookup }}
+        </button>
+      </div>
+
       <div ref="overview">
         <h2 class="govuk-heading-l">
           Overview of the role
         </h2>
 
         <CustomHTML
-          :value="vacancy.roleSummary"
+          :value="language === LANGUAGES.WELSH ? vacancy.roleSummaryWelsh : vacancy.roleSummary"
           class="govuk-body"
         />
 
@@ -316,7 +336,7 @@
           About the role
         </h2>
         <CustomHTML
-          :value="vacancy.aboutTheRole"
+          :value="language === LANGUAGES.WELSH ? vacancy.aboutTheRoleWelsh : vacancy.aboutTheRole"
           class="govuk-body"
         />
       </div>
@@ -365,6 +385,7 @@ export default {
       activeSideNavLink: 'overview',
       isVacancyOpen: false,
       LANGUAGES,
+      language: LANGUAGES.ENGLISH,
       isExpandTimeline: false,
     };
   },
@@ -480,6 +501,9 @@ export default {
         this.toggleExpandTimeline();
       }
       window.print();
+    },
+    setLanguage(language) {
+      this.language = language;
     },
   },
 };


### PR DESCRIPTION
## What's included?
Add a button to switch the language of vacancy information between English and Welsh.

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
1. Go to the details of a vacancy with Welsh posts.
2. Check if you can switch the language between English and Welsh.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Demo:

https://github.com/jac-uk/apply/assets/79906532/1bf5e200-8441-4543-afd4-b7fcc23d099c

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
