### PR TITLE
1006 Added auto-tabbing to the day and month fields

### DIFF
--- a/src/components/Form/DateInput.vue
+++ b/src/components/Form/DateInput.vue
@@ -54,6 +54,7 @@
               v-model.lazy="dayInput"
               class="govuk-input govuk-date-input__input govuk-input--width-2"
               type="number"
+              @input="changeDay"
             >
           </div>
         </div>
@@ -71,6 +72,7 @@
               v-model.lazy="monthInput"
               class="govuk-input govuk-date-input__input govuk-input--width-2"
               type="number"
+              @input="changeMonth"
             >
           </div>
         </div>
@@ -211,6 +213,18 @@ export default {
         date2 instanceof Date &&
         date1.getTime() === date2.getTime()
       );
+    },
+    changeDay(e) {
+      const value = e.target.value;
+      if (value.length === 2) {
+        this.$refs.monthInput.select();
+      }
+    },
+    changeMonth(e) {
+      const value = e.target.value;
+      if (value.length === 2) {
+        this.$refs.yearInput.select();
+      }
     },
   },
 };


### PR DESCRIPTION
## What's included?
Added auto-tabbing to the day and month fields.

closes #1006 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Go to the Your Profile page and scroll down to the date of birth.
Click in to the day field (empty it if it already has a value). Type in a new value and it should tab to the month field.
Do the same in the month field and it should tab to the year field.

See video:

https://github.com/jac-uk/apply/assets/115651787/5d93fd13-5c7d-4e67-b4d4-7b17e0954f21

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work
🟠 Medium risk - this does change code that is shared with other areas
🔴 High risk - this includes a lot of changes to shared code

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
