### PR TITLE
fix styling for save

### DIFF
--- a/src/views/Profile/Edit.vue
+++ b/src/views/Profile/Edit.vue
@@ -58,7 +58,7 @@
             </h3>
             <div class="text-right govuk-!-margin-bottom-4">
               <a
-                class="govuk-link govuk-body-m"
+                class="govuk-button info-btn--character-information--save-and-continue"
                 style="cursor: pointer;"
                 @click.prevent="save"
               >
@@ -143,7 +143,7 @@
 
             <div class="text-right govuk-!-margin-top-8 govuk-!-margin-bottom-4">
               <a
-                class="govuk-link govuk-body-m"
+                class="govuk-button info-btn--character-information--save-and-continue"
                 style="cursor: pointer;"
                 @click.prevent="save"
               >
@@ -200,7 +200,7 @@ export default {
   methods: {
     async save() {
       this.validate();
-      if (this.isValid()) {        
+      if (this.isValid()) {
         const data = this.$store.getters['candidate/personalDetails']();
         let isSuccess = true;
         if (this.personalDetails.email !== data.email) {

--- a/src/views/Profile/Edit.vue
+++ b/src/views/Profile/Edit.vue
@@ -47,27 +47,32 @@
         </nav>
       </div>
 
+      <BackLink />
+
       <div class="govuk-!-padding-top-4 govuk-grid-column-three-quarters">
         <div
           v-if="personalDetails"
           class="govuk-grid-row"
         >
           <div class="govuk-grid-column-three-quarters">
-            <h3 class="govuk-heading-l">
+            <ErrorSummary :errors="errors" />
+            <h3 class="govuk-heading-l float-left">
               Your profile
             </h3>
-            <div class="text-right govuk-!-margin-bottom-4">
+            <!--
+              <div class="text-right govuk-!-margin-bottom-4">
               <a
-                class="govuk-button info-btn--character-information--save-and-continue"
+                class="govuk-button"
                 style="cursor: pointer;"
                 @click.prevent="save"
               >
                 Save
               </a>
             </div>
+            -->
+          </div>
 
-            <ErrorSummary :errors="errors" />
-
+          <div class="govuk-grid-column-three-quarters">
             <TextField
               id="title"
               v-model="personalDetails.title"
@@ -147,7 +152,7 @@
                 style="cursor: pointer;"
                 @click.prevent="save"
               >
-                Save
+                Save and Continue
               </a>
             </div>
           </div>
@@ -163,6 +168,7 @@ import Form from '@/components/Form/Form';
 import ErrorSummary from '@/components/Form/ErrorSummary';
 import TextField from '@/components/Form/TextField';
 import DateInput from '@/components/Form/DateInput';
+import BackLink from '@/components/BackLink';
 
 export default {
   name: 'ProfileEdit',
@@ -170,6 +176,7 @@ export default {
     ErrorSummary,
     TextField,
     DateInput,
+    BackLink,
   },
   extends: Form,
   data() {

--- a/src/views/Profile/PasswordEdit.vue
+++ b/src/views/Profile/PasswordEdit.vue
@@ -47,25 +47,29 @@
         </nav>
       </div>
 
+      <BackLink />
+
       <div class="govuk-!-padding-top-4 govuk-grid-column-three-quarters">
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-three-quarters">
-            <h3 class="govuk-heading-l">
+            <ErrorSummary :errors="errors" />
+            <h3 class="govuk-heading-l float-left">
               Your profile
             </h3>
-
-            <div class="text-right govuk-!-margin-bottom-4">
+            <!--
+              <div class="float-right">
               <a
-                class="govuk-link govuk-body-m"
+                class="govuk-button"
                 style="cursor: pointer;"
                 @click.prevent="save"
               >
-                Save
+                Save and continue
               </a>
-            </div>
+              </div>
+          -->
+          </div>
 
-            <ErrorSummary :errors="errors" />
-
+          <div class="govuk-grid-column-three-quarters">
             <Password
               id="password"
               v-model="password"
@@ -75,6 +79,13 @@
               :min-length="minPasswordLength"
               required
             />
+            <a
+              class="govuk-button float-right"
+              style="cursor: pointer;"
+              @click.prevent="save"
+            >
+              Save and continue
+            </a>
           </div>
         </div>
       </div>
@@ -87,11 +98,13 @@ import { auth } from '@/firebase';
 import Form from '@/components/Form/Form';
 import ErrorSummary from '@/components/Form/ErrorSummary';
 import Password from '@/components/Form/Password';
+import BackLink from '@/components/BackLink';
 
 export default {
   name: 'ProfileEdit',
   components: {
     ErrorSummary,
+    BackLink,
     Password,
   },
   extends: Form,

--- a/src/views/Profile/View.vue
+++ b/src/views/Profile/View.vue
@@ -53,14 +53,14 @@
           class="govuk-grid-row"
         >
           <div class="govuk-grid-column-three-quarters">
-            <h3 class="govuk-heading-l">
+            <h3 class="float-left govuk-heading-l">
               Your profile
             </h3>
 
-            <div class="text-right">
+            <!-- style="display:inline-block;" -->
+            <div class="float-right">
               <RouterLink
                 class="govuk-link govuk-body-m"
-                style="display:inline-block;"
                 :to="{ name: 'profile-edit' }"
               >
                 Edit
@@ -161,16 +161,6 @@
               </div>
             </dl>
 
-            <div class="text-right">
-              <RouterLink
-                class="govuk-link govuk-body-m"
-                style="display:inline-block;"
-                :to="{ name: 'profile-password-edit' }"
-              >
-                Edit
-              </RouterLink>
-            </div>
-
             <dl class="govuk-summary-list">
               <div class="govuk-summary-list__row">
                 <dt class="govuk-summary-list__key">
@@ -178,22 +168,29 @@
                 </dt>
                 <dd class="govuk-summary-list__value">
                   ********
+                  <RouterLink
+                    class="govuk-link govuk-body-m float-right"
+                    style="display:inline-block;"
+                    :to="{ name: 'profile-password-edit' }"
+                  >
+                    Edit
+                  </RouterLink>
                 </dd>
               </div>
             </dl>
           </div>
         </div>
       </div>
-
-      <Modal
-        ref="modalRef"
-        button-text="OK"
-        :cancelable="false"
-        title="Change of email address"
-        message="Your email address has been changed. Please sign in again using your new email address."
-        @confirmed="signOut"
-      />
     </div>
+
+    <Modal
+      ref="modalRef"
+      button-text="OK"
+      :cancelable="false"
+      title="Change of email address"
+      message="Your email address has been changed. Please sign in again using your new email address."
+      @confirmed="signOut"
+    />
   </div>
 </template>
 


### PR DESCRIPTION
## What's included?
Tidy up of the new profile edit pages, using the 'save and continue' button and styling for the buttons.
Nudged a few elements around to have the page slightly more inline. 

## Who should test?
✅ Product owner
✅ Developers

## How to test?
Go to the profile edit page and observe the changes.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
### Before 
view
![image](https://github.com/jac-uk/apply/assets/44227249/02bb188f-a40f-48b5-9137-f28fbeb93748)
edit
![image](https://github.com/jac-uk/apply/assets/44227249/fba40883-6b5e-40dc-8ed2-2a3a617dd847)
edit pw
![image](https://github.com/jac-uk/apply/assets/44227249/eaff9644-d933-451e-964f-3029aecc26e6)

### After
view
![image](https://github.com/jac-uk/apply/assets/44227249/edb1cb9b-e190-4af0-b32b-9bcd4d77f3d1)
edit
![image](https://github.com/jac-uk/apply/assets/44227249/02527e07-468b-4789-93e1-7366cdd7d5e2)
edit pw
![image](https://github.com/jac-uk/apply/assets/44227249/aad945e9-81ca-4c54-8d8c-4cae9a553f84)

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_