### PR TITLE
Remove drop down from ranked selection 

### DIFF
--- a/src/components/SelectionInput/RankedChoice.vue
+++ b/src/components/SelectionInput/RankedChoice.vue
@@ -1,39 +1,37 @@
 <template>
-  <div class="govuk-checkboxes">
+  <div>
     <div
       v-for="(answer, index) in answers"
       :key="index"
-      class="govuk-checkboxes__item"
+      class="govuk-grid-row govuk-!-margin-left-2"
     >
-      <input
-        :id="`${id}-answer-${index}`"
-        v-model="selected"
-        :name="`${id}-answer-${index}`"
-        :value="answer.answer"
-        type="checkbox"
-        class="govuk-checkboxes__input"
-        @change="update"
+      <div
+        class="govuk-checkboxes__item govuk-grid-column-one-third govuk-!-margin-bottom-0"
       >
-      <label
-        :for="`${id}-answer-${index}`"
-        class="govuk-label govuk-checkboxes__label"
-      >
-        {{ answer.answer }}
-      </label>
-      <select 
-        v-if="selected.indexOf(answer.answer) >= 0"
-        v-model="ranking[answer.answer]"
-        class="govuk-select"
-        @change="update"
-      >
-        <option
-          v-for="score in answers.length"
-          :key="score"
-          :value="score"
+        <input
+          :id="`${id}-answer-${index}`"
+          v-model="selected"
+          :name="`${id}-answer-${index}`"
+          :value="answer.answer"
+          type="checkbox"
+          class="govuk-checkboxes__input"
+          @change="update"
         >
-          {{ score }}
-        </option>
-      </select>      
+        <label
+          :for="`${id}-answer-${index}`"
+          class="govuk-label govuk-checkboxes__label"
+        >
+          {{ answer.answer }}
+        </label>
+      </div>
+      <div
+        v-if="selected.indexOf(answer.answer) >= 0"
+        class="govuk-grid-column-one-third"
+      >
+        <div class="govuk-heading-l govuk-!-margin-bottom-0">
+          {{ selected.indexOf(answer.answer) + 1 }}
+        </div>
+      </div>
     </div>
   </div>
 </template>
@@ -53,8 +51,8 @@ export default {
     },
     value: {
       type: Array,
-      default: function () { 
-        return new Array(); 
+      default: function () {
+        return new Array();
       },
     },
   },
@@ -74,28 +72,9 @@ export default {
   },
   methods: {
     update() {
-      const rankedSelection = [];
-      const cleanedRanking = {};
-      for (let i = 0, len = this.selected.length; i < len; ++i) {
-        if (!this.ranking[this.selected[i]]) { this.ranking[this.selected[i]] = this.selected.length; }
-        rankedSelection.push({ answer: this.selected[i], rank: this.ranking[this.selected[i]] });
-        cleanedRanking[this.selected[i]] = this.ranking[this.selected[i]];
-      }
-      this.ranking = cleanedRanking;
-      this.selected = rankedSelection.sort(( item1, item2 ) => {
-        if (item1.rank < item2.rank) {
-          return -1;
-        } else if (item1.rank > item2.rank) {
-          return 1;
-        } else {
-          return 0;
-        }
-      }).map((item) => {
-        return item.answer;
-      });
       this.$emit('input', this.selected);
     },
-  },  
+  },
 };
 
 </script>

--- a/src/components/SelectionInput/SelectionInput.vue
+++ b/src/components/SelectionInput/SelectionInput.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="govuk-form-group">
-    <fieldset 
+    <fieldset
       class="govuk-fieldset"
       :aria-describedby="`${id}-hint`"
     >
@@ -35,7 +35,7 @@
         :answers="answers"
       />
     </fieldset>
-  </div>  
+  </div>
 </template>
 
 <script>
@@ -49,7 +49,7 @@ export default {
     SingleChoice,
     MultipleChoice,
     RankedChoice,
-  },  
+  },
   props: {
     id: {
       type: String,
@@ -89,7 +89,7 @@ export default {
       case 'multiple-choice':
         return 'Select all that apply';
       case 'ranked-choice':
-        return 'Select and rank all that apply. With 1 being your top choice';
+        return 'Select all that apply in order of preference. With 1 being your top choice';
       default:
         return '';
       }


### PR DESCRIPTION
## What's included?
The UI for ranked choice wasnt quite perfect, the dropdown boxes gave the impression that multiple selections could be given the same rank when this was not the case.
To remedy i have removed the drop down and instead given a number to show the true ranking given, this simplistic approach reflects the way the data is stored and is all round just a bit simpler and more straightforward.

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
- find a ranked choice question in an application such as [0518](https://apply-develop.judicialappointments.digital/apply/ONqUjAzhDS7rjh6dFJLB/)

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work
🟠 Medium risk - this does change code that is shared with other areas
🔴 High risk - this includes a lot of changes to shared code

## Additional context
https://github.com/jac-uk/apply/assets/44227249/57c31c91-a763-4b20-a004-04abe615d6eb
---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
