### PR TITLE
add otherQualifications computed to Qualification view - preventing page from not rendering

### DIFF
--- a/src/components/RepeatableFields/Qualification.vue
+++ b/src/components/RepeatableFields/Qualification.vue
@@ -163,7 +163,11 @@ export default {
       return `qualification_type_${this.index}`;
     },
     otherQualificationsRequired() {
-      return this.vacancy.qualifications && this.vacancy.qualifications.includes('other') && this.vacancy.otherQualifications;
+      if (this.vacancy.qualifications) {
+        return this.vacancy.qualifications.includes('other') && this.vacancy.otherQualifications;
+      } else {
+        return false;
+      }
     },
     qualificationLocation() {
       return `qualification_location_${this.index}`;

--- a/src/components/RepeatableFields/Qualification.vue
+++ b/src/components/RepeatableFields/Qualification.vue
@@ -25,7 +25,7 @@
       />
 
       <RadioItem
-        v-if="vacancy.qualifications.includes('other') && vacancy.otherQualifications"
+        v-if="otherQualificationsRequired"
         :value="vacancy.otherQualifications"
         :label="vacancy.otherQualifications"
       />
@@ -161,6 +161,9 @@ export default {
   computed: {
     qualificationType() {
       return `qualification_type_${this.index}`;
+    },
+    otherQualificationsRequired() {
+      return this.vacancy.qualifications && this.vacancy.qualifications.includes('other') && this.vacancy.otherQualifications;
     },
     qualificationLocation() {
       return `qualification_location_${this.index}`;


### PR DESCRIPTION
## What's included?
Qualifications view was breaking trying to read null - see sentry ticket/linked issue #1034 

## Who should test?
✅ Product owner
✅ Developers

## How to test?
- Find an exercise that has `qualifications` set to `null` (example: http://localhost:8181/apply/ONqUjAzhDS7rjh6dFJLB/relevant-qualifications)
- ensure the repeatable field still loads.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
