### PR TITLE
Admin #2125 Diversity Monitoring Report

### DIFF
--- a/src/views/Apply/AccountProfile/EqualityAndDiversitySurvey.vue
+++ b/src/views/Apply/AccountProfile/EqualityAndDiversitySurvey.vue
@@ -556,21 +556,6 @@
             label="Male"
           />
           <RadioItem
-            value="gender-neutral"
-            label="Gender neutral"
-          />
-          <RadioItem
-            value="other-gender"
-            label="Other sex"
-          >
-            <TextField
-              id="other-gender-details"
-              v-model="equalityAndDiversitySurvey.otherGenderDetails"
-              label="Other sex"
-              class="govuk-!-width-two-thirds"
-            />
-          </RadioItem>
-          <RadioItem
             value="prefer-not-to-say"
             label="Prefer not to say"
           />


### PR DESCRIPTION
## What's included?
Removed 'gender-netral' and 'other' from form so that applicants can no longer select it.

This PR is linked to: https://github.com/jac-uk/admin/pull/2126

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?

- Create a new application for a vacancy
- When you get to the Equality And Diversity page ensure that under the 'What is your sex?' question you do not have the option to choose either 'Gender neutral' nor 'Other'

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
