### PR TITLE
#1046 Only Show Downloads Panel If There Are Some

### DIFF
--- a/src/views/Vacancy/VacancyDetails.vue
+++ b/src/views/Vacancy/VacancyDetails.vue
@@ -383,6 +383,7 @@ import exerciseTimeline from '@/helpers/Timeline/exerciseTimeline';
 import DownloadLink from '@/components/DownloadLink.vue';
 import { ADVERT_TYPES, LANGUAGES } from '@/helpers/constants';
 import CustomHTML from '@/components/CustomHTML.vue';
+import _has from 'lodash/has';
 
 export default {
   name: 'VacancyDetails',
@@ -425,6 +426,9 @@ export default {
     vacancy () {
       return this.$store.state.vacancy.record;
     },
+    hasDownloads() {
+      return _has(this.vacancy, 'downloads') && Object.keys(this.vacancy.downloads).length > 0;
+    },
     user() {
       return this.$store.state.auth.currentUser;
     },
@@ -460,7 +464,7 @@ export default {
       return this.advertType === ADVERT_TYPES.FULL;
     },
     showDownload() {
-      return this.advertType !== ADVERT_TYPES.BASIC && this.vacancy.downloads;
+      return this.advertType !== ADVERT_TYPES.BASIC && this.hasDownloads;
     },
     showApplyButton() {
       return this.advertTypeFull || this.advertType === ADVERT_TYPES.BASIC;

--- a/src/views/Vacancy/VacancyDetails.vue
+++ b/src/views/Vacancy/VacancyDetails.vue
@@ -460,7 +460,7 @@ export default {
       return this.advertType === ADVERT_TYPES.FULL;
     },
     showDownload() {
-      return this.advertType !== ADVERT_TYPES.BASIC && vacancy.downloads;
+      return this.advertType !== ADVERT_TYPES.BASIC && this.vacancy.downloads;
     },
     showApplyButton() {
       return this.advertTypeFull || this.advertType === ADVERT_TYPES.BASIC;

--- a/src/views/Vacancy/VacancyDetails.vue
+++ b/src/views/Vacancy/VacancyDetails.vue
@@ -460,7 +460,7 @@ export default {
       return this.advertType === ADVERT_TYPES.FULL;
     },
     showDownload() {
-      return this.advertType !== ADVERT_TYPES.BASIC;
+      return this.advertType !== ADVERT_TYPES.BASIC && vacancy.downloads;
     },
     showApplyButton() {
       return this.advertTypeFull || this.advertType === ADVERT_TYPES.BASIC;


### PR DESCRIPTION
## What's included?
On the Vacancy Details page only display the Relevant Information (Downloads) if there are some.

The following vacancy should NOT have a 'Relevant Information (Downloads)' section:

https://jac-apply-develop--pr1063-hotfix-1046-show-dow-uugbz500.web.app/vacancy/xpML6eLU4dJrZAkBJ5cW

The following vacancy SHOULD have a 'Relevant Information (Downloads)' section:

https://jac-apply-develop--pr1063-hotfix-1046-show-dow-uugbz500.web.app/vacancy/LESgeszgHok7jm6UjrCj

Closes #1046 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Ensure if there are no downloads then the 'Relevant Information (Downloads)' section does not display at all.
If there are downloads then it should.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
