### PR TITLE
#1043 Qualifications Should Only Appear For Legal Exercises

### DIFF
--- a/src/views/Apply/TaskList.vue
+++ b/src/views/Apply/TaskList.vue
@@ -99,6 +99,7 @@
         </TaskGroup>
 
         <TaskGroup
+          v-if="isLegal"
           :title="experienceTitle"
         >
           <Task

--- a/src/views/Apply/TaskList.vue
+++ b/src/views/Apply/TaskList.vue
@@ -98,12 +98,9 @@
           />
         </TaskGroup>
 
-        <TaskGroup
-          v-if="isLegal"
-          :title="experienceTitle"
-        >
+        <TaskGroup :title="experienceTitle">
           <Task
-            v-if="applicationParts.relevantQualifications"
+            v-if="applicationParts.relevantQualifications && isLegal"
             id="relevant-qualifications"
             title="Relevant qualifications"
             :done="applicationProgress.relevantQualifications"


### PR DESCRIPTION
## What's included?
When applying for a vacancy ensure the Qualifications section only appears for non-legal exercises.

Closes #1043 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?

Test 1
- Go to this page and login: https://jac-apply-develop--pr1064-hotfix-1043-qualific-l14x0yls.web.app
- Click on the 'v2 Flag Check' vacancy
- Apply for the vacancy
- Click through the application steps until you get to the Apply For The Role page
- On this page check that you do NOT see a Qualifications & Experience section

Test 2
- Go to this page: https://jac-apply-develop--pr1064-hotfix-1043-qualific-l14x0yls.web.app
- Click on the 'JAC00582 Salaried Judge of the Mental Health Review Tribunal for Wales (MHRTW) COPY Testing New' vacancy
- Apply for the vacancy
- Click through the application steps until you get to the Apply For The Role page
- On this page check that you DO see a  Qualifications & Experience section

See screenshot below:

<img width="1369" alt="Screenshot 2023-09-26 at 10 06 42" src="https://github.com/jac-uk/apply/assets/115651787/14cd9ee2-625a-4b49-bea2-2536480e02a9">

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
