### PR TITLE
Bugfix/1002 Empty task group

### DIFF
--- a/src/components/Page/TaskList/TaskGroup.vue
+++ b/src/components/Page/TaskList/TaskGroup.vue
@@ -36,7 +36,7 @@ export default {
     checkForSlotContent() {
       const checkForContent = (hasContent, node) => {
         // for some reason the property tag and text are not available in the node object after using vite
-        return hasContent || node.type || node.tag || (node.text && node.text.trim());
+        return hasContent || !!(node.type && node.type.name) || !!node.tag || !!(node.text && node.text.trim());
       };
       return this.$slots.default() && this.$slots.default().reduce(checkForContent, false);
     },


### PR DESCRIPTION
## What's included?
"Apply for the role" includes empty headings. The Vue3 upgrade causes this.

Steps to reproduce:
1. Create/use an exercise which has a staged application process.
2. Try to apply to the exercise and observe the Apply for the role task list. It includes empty headings - e.g. In the screenshot Assessments and Additional Information should not be showing.

    ![image](https://github.com/jac-uk/apply/assets/79906532/821c5903-975c-47df-a937-571162625d4e)

    It should be like below:

    ![image](https://github.com/jac-uk/apply/assets/79906532/3df6041a-3190-40be-8e57-5179b4f2b044)


## Who should test?
✅ Product owner
✅ Developers

## How to test?
Example exercise: https://jac-apply-develop--pr1081-bugfix-1002-empty-ta-34t5c2rq.web.app/vacancy/euHYlnsu1DdSlSkve2BW/

1. Apply for a vacancy.
2. Go to the Apply for the role task list and check if the empty headings are not showing.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, notes etc.

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
