### PR TITLE
Bugfix/1074 Sign in after reset password

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "application-form",
-  "version": "1.73.4",
+  "version": "1.73.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "application-form",
-      "version": "1.73.4",
+      "version": "1.73.5",
       "dependencies": {
         "@jac-uk/jac-kit": "^0.1.26",
         "@ministryofjustice/frontend": "0.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "application-form",
-  "version": "1.73.4",
+  "version": "1.73.5",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve --mode develop",

--- a/src/main.js
+++ b/src/main.js
@@ -46,6 +46,8 @@ auth.onAuthStateChanged( (user) => {
   const urlParams = new URLSearchParams(window.location.search);
   const nextPage = urlParams.get('nextPage');
   if (nextPage) router.push(nextPage);
+  else router.push('/vacancies');
+  
   if (!vueInstance) {
     vueInstance = new Vue({
       el: '#app',

--- a/src/main.js
+++ b/src/main.js
@@ -43,10 +43,12 @@ Object.keys(filters)
 let vueInstance = false;
 auth.onAuthStateChanged( (user) => {
   store.dispatch('auth/setCurrentUser', user);
-  const urlParams = new URLSearchParams(window.location.search);
-  const nextPage = urlParams.get('nextPage');
-  if (nextPage) router.push(nextPage);
-  else router.push('/vacancies');
+  if (store.getters['auth/isSignedIn']) {
+    const urlParams = new URLSearchParams(window.location.search);
+    const nextPage = urlParams.get('nextPage');
+    if (nextPage) router.push(nextPage);  
+    else router.push('/vacancies');
+  }
   
   if (!vueInstance) {
     vueInstance = new Vue({

--- a/src/views/ResetPassword.vue
+++ b/src/views/ResetPassword.vue
@@ -76,6 +76,11 @@ export default {
       resetSent: false,
     };
   },
+  computed: {
+    nextPage() {
+      return this.$route.query.nextPage;
+    },
+  },
   methods: {
     async submit() {
       if (!this.formData.email) return;
@@ -101,7 +106,10 @@ export default {
     },
     async resetPassword() {
       if (this.formData.email) {
-        const returnUrl = location.origin + this.$router.resolve({ name: 'sign-in' }).route.fullPath;
+        let returnUrl = location.origin + this.$router.resolve({ name: 'sign-in' }).route.fullPath;
+        if (this.nextPage) {
+          returnUrl += `?nextPage=${this.nextPage}`;
+        }
         this.errors = [];
         auth.sendPasswordResetEmail(this.formData.email, {
           url: returnUrl,

--- a/src/views/SignIn.vue
+++ b/src/views/SignIn.vue
@@ -65,7 +65,7 @@
             <RouterLink
               class="govuk-link"
               data-module="govuk-button"
-              :to="{ name: 'reset-password' }"
+              :to="{ name: 'reset-password', query: { nextPage: nextPage } }"
             >
               Reset your password
             </RouterLink>


### PR DESCRIPTION
## What's included?
Closes #1074 

- Configure `nextPage` parameter when resetting the password.
- Redirect to the default page (e.g. vacancies) if `nextPage` is empty.

## Who should test?
✅ Product owner
✅ Developers

## How to test?

Scenario 1:
1. Go to the sign-in page directly: https://jac-apply-develop--pr1085-bugfix-1074-sign-in-7mylblla.web.app/sign-in
2. Sign in and check if the page redirects to the vacancies page.

Scenario 2:
1. Make sure you have not signed in.
2. Go to the vacancy details page: https://jac-apply-develop--pr1085-bugfix-1074-sign-in-7mylblla.web.app/vacancy/5MC34wbOTnI8BuOIsGUR/
3. Click on `Sign In` button and the page will go to the sign in page.
4. Click on `Reset your password` link and the page will go to the forgotten password page.
5. Enter your email address and reset your password.
6. After the password has been reset the page will redirect to the sign in page.
7. Sign in again and check if the page redirects to the vacancy details page.

    https://github.com/jac-uk/apply/assets/79906532/5a545d33-b463-48c6-8c3b-457537a808a8

    https://github.com/jac-uk/apply/assets/79906532/d37f1cb9-a0ce-4364-af38-457d48114625



## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, notes etc.

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
