### PR TITLE
Feature/1037 warn when using cps devices

### DIFF
--- a/src/components/Form/Form.vue
+++ b/src/components/Form/Form.vue
@@ -43,26 +43,22 @@ export default {
           this.errors.push({ id: item, message: this.errorObject[item] });
         }
       }
-      if (!this.isValid()) {
-        this.scrollToErrorSummary();
-        setTimeout(() => {
-          updateLangToTextNode(document.querySelector('#main-content'), this.language);
-        }, 0);
-      }
+      this.updateAndScroll();
     },
     handleWarning(payload) {
       this.warningObject = {id: payload.id, message: payload.message};
-      this.scrollToErrorSummary();
-      setTimeout(() => {
+      this.updateAndScroll();
+    },
+    updateAndScroll() {
+      this.$nextTick(() => {
         updateLangToTextNode(document.querySelector('#main-content'), this.language);
-      }, 0);
+        this.scrollToErrorSummary();
+      });
     },
     scrollToErrorSummary(){
       //This is just scrolling to top of page
-      this.$el.scrollIntoView();
-    },
-    isValid() {
-      return this.errors.length === 0;
+      window.setTimeout( ()=>{ this.$el.scrollIntoView(true); }, 50 );
+
     },
   },
 };

--- a/src/components/Form/Form.vue
+++ b/src/components/Form/Form.vue
@@ -11,6 +11,7 @@ export default {
     return {
       errorObject: {},
       errors: [],
+      warningObject: null,
     };
   },
   computed: {
@@ -20,6 +21,7 @@ export default {
   },
   mounted: function () {
     this.emitter.on('handle-error', this.handleError);
+    this.emitter.on('handle-warning', this.handleWarning);
     // Disable HTML5 validation
     if (this.$refs.formRef) {
       this.$refs.formRef.setAttribute('novalidate', true);
@@ -27,6 +29,7 @@ export default {
   },
   beforeUnmount: function() {
     this.emitter.off('handle-error', this.handleError);
+    this.emitter.off('handle-warning', this.handleWarning);
   },
   methods: {
     async validate() {
@@ -46,6 +49,13 @@ export default {
           updateLangToTextNode(document.querySelector('#main-content'), this.language);
         }, 0);
       }
+    },
+    handleWarning(payload) {
+      this.warningObject = {id: payload.id, message: payload.message};
+      this.scrollToErrorSummary();
+      setTimeout(() => {
+        updateLangToTextNode(document.querySelector('#main-content'), this.language);
+      }, 0);
     },
     scrollToErrorSummary(){
       //This is just scrolling to top of page

--- a/src/components/Form/FormField.vue
+++ b/src/components/Form/FormField.vue
@@ -55,6 +55,7 @@ export default {
   data() {
     return {
       errorMessage: '',
+      warningMessage: '',
       checkErrors: false,
       regex: {
         // eslint-disable-next-line
@@ -91,12 +92,17 @@ export default {
   },
   beforeUnmount: function() {
     this.setError('');
+    this.setWarning('');
     this.emitter.off('validate', this.handleValidate);
   },
   methods: {
     setError(message) {
       this.errorMessage = message;
       this.emitter.emit('handle-error', { id: this.id, message: this.errorMessage });
+    },
+    setWarning(message) {
+      this.warningMessage = message;
+      this.emitter.emit('handle-warning', { id: this.id, message: this.warningMessage });
     },
     handleValidate() {
       this.checkErrors = true;

--- a/src/components/Form/TextField.vue
+++ b/src/components/Form/TextField.vue
@@ -86,9 +86,9 @@ export default {
       default: 'text',
       type: String,
     },
-    warnCPSEmail: {
-      default: false,
-      type: Boolean,
+    warnCPSEmailMsg: {
+      required: false,
+      type: String,
     },
   },
   emits: ['update:modelValue'],
@@ -132,8 +132,8 @@ export default {
   },
   watch: {
     text() {
-      if (this.warnCPSEmail && this.isCPSEmail()) {
-        this.setWarning('Use of a CPS device causes multiple known issues with the JAC Digital Platform due to the device firewall settings - it is strongly recommended that applicants use a personal device to log on/submit an application.');
+      if (this.warnCPSEmailMsg && this.isCPSEmail()) {
+        this.setWarning(this.warnCPSEmailMsg);
       }
     },
   },

--- a/src/components/Form/TextField.vue
+++ b/src/components/Form/TextField.vue
@@ -86,6 +86,10 @@ export default {
       default: 'text',
       type: String,
     },
+    warnCPSEmail: {
+      default: false,
+      type: Boolean,
+    },
   },
   emits: ['update:modelValue'],
   computed: {
@@ -93,11 +97,11 @@ export default {
       get() {
         return this.modelValue;
       },
-      set(val) { 
+      set(val) {
         if (typeof val === 'string') {
           val = val.trim();
         }
-        
+
         switch (this.type) {
         case 'number':
           this.$emit('update:modelValue', val ? parseFloat(val) : '');
@@ -124,6 +128,28 @@ export default {
       default:
         return this.type;
       }
+    },
+  },
+  watch: {
+    text() {
+      if (this.warnCPSEmail && this.isCPSEmail()) {
+        this.setWarning('Use of a CPS device causes multiple known issues with the JAC Digital Platform due to the device firewall settings - it is strongly recommended that applicants use a personal device to log on/submit an application.');
+      }
+    },
+  },
+  methods: {
+    isCPSEmail() {
+      if (this.text) {
+        const domain = 'cps';
+        const extension = 'gov.uk';
+
+        // Define a regular expression pattern to match the email address
+        const pattern = new RegExp(`^\\w+@${domain}\\.${extension}$`, 'i');
+
+        // Use the RegExp.test() method to check if the email matches the pattern
+        return pattern.test(this.text);
+      }
+      return false;
     },
   },
 };

--- a/src/components/Form/WarningSummary.vue
+++ b/src/components/Form/WarningSummary.vue
@@ -1,0 +1,29 @@
+<template>
+  <div
+    v-if="warningObject"
+    aria-labelledby="error-summary-title"
+    role="alert"
+    tabindex="-1"
+    data-module="govuk-error-summary"
+  >
+  <div class="govuk-warning-text">
+    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+    <strong class="govuk-warning-text__text">
+      <span class="govuk-warning-text__assistive">Warning</span>
+        {{ warningObject.message }}
+    </strong>
+  </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'WarningSummary',
+  props: {
+    warningObject: {
+      type: Object,
+      required: false,
+    },
+  },
+};
+</script>

--- a/src/components/Form/WarningSummary.vue
+++ b/src/components/Form/WarningSummary.vue
@@ -1,10 +1,11 @@
 <template>
   <div
     v-if="warningObject"
-    aria-labelledby="error-summary-title"
+    class="govuk-warning-summary"
+    aria-labelledby="warning-summary-title"
     role="alert"
     tabindex="-1"
-    data-module="govuk-error-summary"
+    data-module="govuk-warning-summary"
   >
   <div class="govuk-warning-text">
     <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
@@ -27,3 +28,13 @@ export default {
   },
 };
 </script>
+<style scoped>
+.govuk-warning-summary {
+  border: 5px solid black;
+  margin-bottom: 50px;
+  padding: 20px;
+}
+.govuk-warning-text {
+  margin-bottom: 0;
+}
+</style>

--- a/src/views/Apply/Assessments/AssessorsDetails.vue
+++ b/src/views/Apply/Assessments/AssessorsDetails.vue
@@ -119,7 +119,7 @@
           v-model="formData.firstAssessorEmail"
           label="Email"
           type="email"
-          :warnCPSEmail="true"
+          :warnCPSEmailMsg="assessorEmailWarning"
           required
         />
         <TextField
@@ -166,7 +166,7 @@
           v-model="formData.secondAssessorEmail"
           label="Email"
           type="email"
-          :warnCPSEmail="true"
+          :warnCPSEmail="assessorEmailWarning"
           required
         />
         <TextField
@@ -230,6 +230,9 @@ export default {
       formId: 'assessorsDetails',
       formData: formData,
     };
+  },
+  created() {
+    this.assessorEmailWarning = 'Use of a CPS device causes multiple known issues with the JAC Digital Platform due to the device firewall settings - it is strongly recommended that a non-CPS email address is provided for Independent Assessors.';
   },
 };
 </script>

--- a/src/views/Apply/Assessments/AssessorsDetails.vue
+++ b/src/views/Apply/Assessments/AssessorsDetails.vue
@@ -119,7 +119,7 @@
           v-model="formData.firstAssessorEmail"
           label="Email"
           type="email"
-          :warnCPSEmailMsg="assessorEmailWarning"
+          warnCPSEmailMsg="Use of a CPS device causes multiple known issues with the JAC Digital Platform due to the device firewall settings - it is strongly recommended that a non-CPS email address is provided for Independent Assessors."
           required
         />
         <TextField
@@ -166,7 +166,7 @@
           v-model="formData.secondAssessorEmail"
           label="Email"
           type="email"
-          :warnCPSEmail="assessorEmailWarning"
+          warnCPSEmailMsg="Use of a CPS device causes multiple known issues with the JAC Digital Platform due to the device firewall settings - it is strongly recommended that a non-CPS email address is provided for Independent Assessors."
           required
         />
         <TextField
@@ -230,9 +230,6 @@ export default {
       formId: 'assessorsDetails',
       formData: formData,
     };
-  },
-  created() {
-    this.assessorEmailWarning = 'Use of a CPS device causes multiple known issues with the JAC Digital Platform due to the device firewall settings - it is strongly recommended that a non-CPS email address is provided for Independent Assessors.';
   },
 };
 </script>

--- a/src/views/Apply/Assessments/AssessorsDetails.vue
+++ b/src/views/Apply/Assessments/AssessorsDetails.vue
@@ -11,6 +11,7 @@
         </h1>
 
         <ErrorSummary :errors="errors" />
+        <WarningSummary :warningObject="warningObject" />
 
         <p class="govuk-body-l">
           Sometimes called 'referees', your independent assessors will give us
@@ -118,6 +119,7 @@
           v-model="formData.firstAssessorEmail"
           label="Email"
           type="email"
+          :warnCPSEmail="true"
           required
         />
         <TextField
@@ -164,6 +166,7 @@
           v-model="formData.secondAssessorEmail"
           label="Email"
           type="email"
+          :warnCPSEmail="true"
           required
         />
         <TextField
@@ -188,6 +191,7 @@
 <script>
 import Form from '@/components/Form/Form.vue';
 import ErrorSummary from '@/components/Form/ErrorSummary.vue';
+import WarningSummary from '@/components/Form/WarningSummary.vue';
 import ApplyMixIn from '../ApplyMixIn';
 import TextField from '@/components/Form/TextField.vue';
 import BackLink from '@/components/BackLink.vue';
@@ -198,6 +202,7 @@ export default {
   name: 'AssessorsDetails',
   components: {
     ErrorSummary,
+    WarningSummary,
     TextField,
     BackLink,
     Select,

--- a/src/views/SignIn.vue
+++ b/src/views/SignIn.vue
@@ -44,7 +44,7 @@
             v-model="formData.email"
             label="Email address"
             type="email"
-            :warnCPSEmail="true"
+            :warnCPSEmailMsg="signinEmailWarning"
             required
           />
 
@@ -105,6 +105,9 @@ export default {
       formData: {},
       errors: [],
     };
+  },
+  created() {
+    this.signinEmailWarning = 'Use of a CPS device causes multiple known issues with the JAC Digital Platform due to the device firewall settings - it is strongly recommended that applicants use a personal device to log on/submit an application.';
   },
   computed: {
     disabled() {

--- a/src/views/SignIn.vue
+++ b/src/views/SignIn.vue
@@ -37,12 +37,14 @@
           </p> -->
 
           <ErrorSummary :errors="errors" />
+          <WarningSummary :warningObject="warningObject" />
 
           <TextField
             id="email"
             v-model="formData.email"
             label="Email address"
             type="email"
+            :warnCPSEmail="true"
             required
           />
 
@@ -78,7 +80,9 @@
 </template>
 
 <script>
+import Form from '@/components/Form/Form.vue';
 import ErrorSummary from '@/components/Form/ErrorSummary.vue';
+import WarningSummary from '@/components/Form/WarningSummary.vue';
 import ChangeEmailMessage from '@/components/Page/ChangeEmailMessage.vue';
 import TextField from '@/components/Form/TextField.vue';
 import { auth } from '@/firebase';
@@ -90,10 +94,12 @@ export default {
   name: 'SignIn',
   components: {
     ErrorSummary,
+    WarningSummary,
     TextField,
     ChangeEmailMessage,
     Password,
   },
+  extends: Form,
   data () {
     return {
       formData: {},

--- a/src/views/SignIn.vue
+++ b/src/views/SignIn.vue
@@ -44,7 +44,7 @@
             v-model="formData.email"
             label="Email address"
             type="email"
-            :warnCPSEmailMsg="signinEmailWarning"
+            warnCPSEmailMsg="Use of a CPS device causes multiple known issues with the JAC Digital Platform due to the device firewall settings - it is strongly recommended that applicants use a personal device to log on/submit an application."
             required
           />
 
@@ -105,9 +105,6 @@ export default {
       formData: {},
       errors: [],
     };
-  },
-  created() {
-    this.signinEmailWarning = 'Use of a CPS device causes multiple known issues with the JAC Digital Platform due to the device firewall settings - it is strongly recommended that applicants use a personal device to log on/submit an application.';
   },
   computed: {
     disabled() {

--- a/src/views/SignUp.vue
+++ b/src/views/SignUp.vue
@@ -65,7 +65,7 @@
             v-model="formData.email"
             label="Email address"
             type="email"
-            :warnCPSEmail="true"
+            :warnCPSEmailMsg="signinEmailWarning"
             :pattern="{
               match: /^((?!@judicialappointments.gov.uk\s*$).)*$/,
               message: 'You cannot sign up as a candidate using a @judicialappointments.gov.uk email address',
@@ -143,6 +143,9 @@ export default {
       formData: {},
       fullName: null,
     };
+  },
+  created() {
+    this.signinEmailWarning = 'Use of a CPS device causes multiple known issues with the JAC Digital Platform due to the device firewall settings - it is strongly recommended that applicants use a personal device to log on/submit an application.';
   },
   computed: {
     exerciseId () {

--- a/src/views/SignUp.vue
+++ b/src/views/SignUp.vue
@@ -34,6 +34,7 @@
           </p>
 
           <ErrorSummary :errors="errors" />
+          <WarningSummary :warningObject="warningObject" />
 
           <TextField
             id="title"
@@ -64,6 +65,7 @@
             v-model="formData.email"
             label="Email address"
             type="email"
+            :warnCPSEmail="true"
             :pattern="{
               match: /^((?!@judicialappointments.gov.uk\s*$).)*$/,
               message: 'You cannot sign up as a candidate using a @judicialappointments.gov.uk email address',
@@ -118,6 +120,7 @@ import firebase from '@firebase/app';
 import { auth } from '@/firebase';
 import Form from '@/components/Form/Form.vue';
 import ErrorSummary from '@/components/Form/ErrorSummary.vue';
+import WarningSummary from '@/components/Form/WarningSummary.vue';
 import TextField from '@/components/Form/TextField.vue';
 import Password from '@/components/Form/Password.vue';
 import DateInput from '@/components/Form/DateInput.vue';
@@ -127,11 +130,12 @@ export default {
   name: 'SignUp',
   components: {
     ErrorSummary,
+    WarningSummary,
     TextField,
     Password,
     DateInput,
     ChangeEmailMessage,
-  },
+},
   extends: Form,
   data () {
     return {

--- a/src/views/SignUp.vue
+++ b/src/views/SignUp.vue
@@ -65,7 +65,7 @@
             v-model="formData.email"
             label="Email address"
             type="email"
-            :warnCPSEmailMsg="signinEmailWarning"
+            warnCPSEmailMsg="Use of a CPS device causes multiple known issues with the JAC Digital Platform due to the device firewall settings - it is strongly recommended that applicants use a personal device to log on/submit an application."
             :pattern="{
               match: /^((?!@judicialappointments.gov.uk\s*$).)*$/,
               message: 'You cannot sign up as a candidate using a @judicialappointments.gov.uk email address',
@@ -143,9 +143,6 @@ export default {
       formData: {},
       fullName: null,
     };
-  },
-  created() {
-    this.signinEmailWarning = 'Use of a CPS device causes multiple known issues with the JAC Digital Platform due to the device firewall settings - it is strongly recommended that applicants use a personal device to log on/submit an application.';
   },
   computed: {
     exerciseId () {


### PR DESCRIPTION
## What's included?
Add warnings on the sign in and sign up pages as well as the assessor details page to warn the user when the enter a 'cps.gov.uk' email address. The user can choose to ignore the message and continue as usual.

Closes #1037 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?

**Test 1**

- go to the sign in page
- type in a 'cps.gov.uk' email address
- the following warning should immediately display: "Use of a CPS device causes multiple known issues with the JAC Digital Platform due to the device firewall settings - it is strongly recommended that applicants use a personal device to log on/submit an application."
- ignore the warning and proceed as usual anyway (you should be able to submit the form)

**Test 2**

- repeat Test 1 for the signup page

**Test 3**

- login and apply for a vacancy
- go to the Independent Assessors page (under the Assessments section)
- type in a 'cps.gov.uk' email address in either/both of the email inputs on the page and ensure you see the following message (which differs from the one for signin/signup): Use of a CPS device causes multiple known issues with the JAC Digital Platform due to the device firewall settings - it is strongly recommended that a non-CPS email address is provided for Independent Assessors.


## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, notes etc.

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
