### PR TITLE
Feature/Add npm audit checks

### DIFF
--- a/.github/workflows/scheduled-actions.yml
+++ b/.github/workflows/scheduled-actions.yml
@@ -1,0 +1,12 @@
+name: Scheduled actions
+on:
+  schedule:
+    - cron: "22 8 * * *"
+
+jobs:
+  dependency_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Dependency Check
+        run: npm audit --omit=dev

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "is-svg": ">=4.3.0",
         "jest-extended": "^0.11.5",
         "node-fetch": ">=2.6.7",
-        "postcss": "8.2.15",
+        "postcss": "^8.4.31",
         "sass": "^1.32.13",
         "vite-plugin-eslint": "^1.8.1",
         "webpack": "^5.88.2",
@@ -3149,11 +3149,6 @@
       "bin": {
         "color-support": "bin.js"
       }
-    },
-    "node_modules/colorette": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
-      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g=="
     },
     "node_modules/component-emitter": {
       "version": "1.3.0",
@@ -6978,20 +6973,30 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.2.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.15.tgz",
-      "integrity": "sha512-2zO3b26eJD/8rb106Qu2o7Qgg52ND5HPjcyQiK2B98O388h43A448LCslC0dI2P97wCAQRJsFvwTRcXxTKds+Q==",
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
       "dependencies": {
-        "colorette": "^1.2.2",
-        "nanoid": "^3.1.23",
-        "source-map": "^0.6.1"
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/postcss-selector-parser": {
@@ -7725,6 +7730,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8561,33 +8567,6 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/vite/node_modules/postcss": {
-      "version": "8.4.29",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.29.tgz",
-      "integrity": "sha512-cbI+jaqIeu/VGqXEarWkRCCffhjgXc0qjBtXpqJhTBohMUjUQnbBr0xqX3vEKudc4iviTewcJo5ajcec5+wdJw==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/vue": {
@@ -11335,11 +11314,6 @@
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
       "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
       "dev": true
-    },
-    "colorette": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
-      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g=="
     },
     "component-emitter": {
       "version": "1.3.0",
@@ -14311,13 +14285,13 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.2.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.15.tgz",
-      "integrity": "sha512-2zO3b26eJD/8rb106Qu2o7Qgg52ND5HPjcyQiK2B98O388h43A448LCslC0dI2P97wCAQRJsFvwTRcXxTKds+Q==",
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
       "requires": {
-        "colorette": "^1.2.2",
-        "nanoid": "^3.1.23",
-        "source-map": "^0.6.1"
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
       }
     },
     "postcss-selector-parser": {
@@ -14837,7 +14811,8 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "devOptional": true
     },
     "source-map-js": {
       "version": "1.0.2",
@@ -15421,18 +15396,6 @@
         "fsevents": "~2.3.2",
         "postcss": "^8.4.27",
         "rollup": "^3.27.1"
-      },
-      "dependencies": {
-        "postcss": {
-          "version": "8.4.29",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.29.tgz",
-          "integrity": "sha512-cbI+jaqIeu/VGqXEarWkRCCffhjgXc0qjBtXpqJhTBohMUjUQnbBr0xqX3vEKudc4iviTewcJo5ajcec5+wdJw==",
-          "requires": {
-            "nanoid": "^3.3.6",
-            "picocolors": "^1.0.0",
-            "source-map-js": "^1.0.2"
-          }
-        }
       }
     },
     "vite-plugin-eslint": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "is-svg": ">=4.3.0",
     "jest-extended": "^0.11.5",
     "node-fetch": ">=2.6.7",
-    "postcss": "8.2.15",
+    "postcss": "^8.4.31",
     "sass": "^1.32.13",
     "vite-plugin-eslint": "^1.8.1",
     "webpack": "^5.88.2",


### PR DESCRIPTION
## What's included?

- Add a scheduled (daily) check to ensure there are no vulnerabilities (command: `npm audit --omit=dev`)
- Fix vulnerabilities (command: `npm audit fix --force`)
    - postcss

## Who should test?
✅ Developers

## How to test?

1. Run `npm audit --omit=dev` locally and check if no vulnerabilities are found.
2. Check if the scheduled check is running daily after this PR is merged.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, notes etc.

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
