### PR TITLE
Feature/1090 Reconfirm commissioner conflicts

### DIFF
--- a/src/components/CandidateFormViews/CommissionerConflicts.vue
+++ b/src/components/CandidateFormViews/CommissionerConflicts.vue
@@ -1,6 +1,30 @@
 <template>
-  <div>
-    Commissioner conflicts view code goes here
+  <div v-if="application && application.additionalInfo">
+    <dl
+      v-if="application.additionalInfo.commissionerConflicts && application.additionalInfo.commissionerConflicts.length"
+      class="govuk-summary-list govuk-!-margin-bottom-8"
+    >
+      <div
+        v-for="(commissionerConflict, index) in application.additionalInfo.commissionerConflicts"
+        :key="index"
+        class="govuk-summary-list__row"
+      >
+        <dt class="govuk-summary-list__key">
+          {{ commissionerConflict.name }}
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <div v-if="commissionerConflict.hasRelationship === null">
+            No information provided
+          </div>
+          <div v-else>
+            {{ commissionerConflict.hasRelationship ? 'Yes' : 'No' }}
+          </div>
+          <div v-if="commissionerConflict.hasRelationship">
+            {{ commissionerConflict.details }}
+          </div>
+        </dd>
+      </div>
+    </dl>
   </div>
 </template>
 

--- a/src/views/Apply/CommissionerConflicts.vue
+++ b/src/views/Apply/CommissionerConflicts.vue
@@ -12,12 +12,19 @@
 
         <ErrorSummary :errors="errors" />
 
-        <p class="govuk-body-l">
-          Members of the Judicial Appointments Commission (JAC) come from a wide background to ensure the Commission has a breadth of knowledge, expertise and independence.
-        </p>
-        <p class="govuk-body-l">
-          Are you related to, or known to any of the JAC Commissioners? If you are in any doubt then please select 'Yes' in the list below:
-        </p>
+        <template v-if="!customSave">
+          <p class="govuk-body-l">
+            Members of the Judicial Appointments Commission (JAC) come from a wide background to ensure the Commission has a breadth of knowledge, expertise and independence.
+          </p>
+          <p class="govuk-body-l">
+            Are you related to, or known to any of the JAC Commissioners? If you are in any doubt then please select 'Yes' in the list below:
+          </p>
+        </template>
+        <template v-else>
+          <p class="govuk-body-l">
+            Please update this section to take into account any changes since you submitted your application.
+          </p>
+        </template>
 
         <RadioGroup
           v-for="(commissioner , index) in formData.additionalInfo.commissionerConflicts"

--- a/src/views/Apply/CommissionerConflicts.vue
+++ b/src/views/Apply/CommissionerConflicts.vue
@@ -54,7 +54,7 @@
         </div>
 
         <button
-          :disabled="!canSave(formId)"
+          :disabled="!canSave(formId) && !customSave"
           class="govuk-button info-btn--personal-details--save-and-continue"
         >
           Save and continue
@@ -84,6 +84,13 @@ export default {
   },
   extends: Form,
   mixins: [ApplyMixIn],
+  props: {
+    customSave: { // override the default save behaviour
+      type: Function,
+      required: false,
+      default: null,
+    },
+  },
   data() {
     const commissioners = this.$store.state.vacancy.record.commissioners;
     const defaults = {
@@ -133,9 +140,13 @@ export default {
     async save() {
       this.validate();
       if (this.isValid() && this.isFormValid()) {
-        this.formData.progress[this.formId] = true;
         await this.$store.dispatch('application/save', this.formData);
-        this.$router.push({ name: 'task-list' });
+        if (this.customSave) {
+          await this.customSave();
+        } else {
+          this.formData.progress[this.formId] = true;
+          this.$router.push({ name: 'task-list' });
+        }
       }
     },
   },

--- a/src/views/Apply/Forms/Parts/CommissionerConflicts.vue
+++ b/src/views/Apply/Forms/Parts/CommissionerConflicts.vue
@@ -1,27 +1,18 @@
 <template>
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <BackLink />
-      <h1 class="govuk-heading-xl">
-        Commissioner Conflicts
-      </h1>
-      <button
-        class="govuk-button info-btn--candidate-availability--save-and-continue"
-        @click="save()"
-      >
-        Save and continue
-      </button>
-    </div>
+    <CommissionerConflicts :custom-save="save" />
   </div>
 </template>
+
 <script>
 import { APPLICATION_FORM_PARTS } from '@/helpers/constants';
-import BackLink from '@/components/BackLink.vue';
+import CommissionerConflicts from '@/views/Apply/CommissionerConflicts.vue';
 import CandidateFormsMixIn from '@/views/Apply/Forms/CandidateFormsMixIn';
+
 export default {
   name: 'CandidateFormCommissionerConflicts',
   components: {
-    BackLink,
+    CommissionerConflicts,
   },
   mixins: [CandidateFormsMixIn],
   created() {


### PR DESCRIPTION
## What's included?
Closes #1090 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?

Use the following email addresses (password: 1qazZAQ!1qaz) to sign in to the apply side:
- application-0001@jac-dummy-email.jac
- application-0002@jac-dummy-email.jac
- application-0003@jac-dummy-email.jac
- application-0004@jac-dummy-email.jac
- application-0005@jac-dummy-email.jac
- application-0006@jac-dummy-email.jac
- application-0007@jac-dummy-email.jac
- application-0008@jac-dummy-email.jac

Steps:
1. Go to "Current applications" and click the button "Pre Selection Day Questionnaire" under exercise JAC00685.
2. Check if you can see the "Commissioner Conflicts" in the list.
3. Go to "Commissioner conflicts" and check if you can reconfirm the commissioner conflicts.
4. Click "Save and continue" and check if "Commissioner Conflicts" is marked as "DONE".

## Risk - how likely is this to impact other areas?
🟠 Medium risk - this does change code that is shared with other areas

## Additional context
Demo:

https://github.com/jac-uk/apply/assets/79906532/86925cfd-0b69-4d97-8272-8e2b5b5ecc39

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
