### PR TITLE
#1110 CPS Email Warning Doesnt Show When Dot Used In Email Address

### DIFF
--- a/src/components/Form/TextField.vue
+++ b/src/components/Form/TextField.vue
@@ -151,7 +151,7 @@ export default {
         const extension = 'gov.uk';
 
         // Define a regular expression pattern to match the email address
-        const pattern = new RegExp(`^\\w+@${domain}\\.${extension}$`, 'i');
+        const pattern = new RegExp(`^.+@${domain}\\.${extension}$`, 'i');
 
         // Use the RegExp.test() method to check if the email matches the pattern
         return pattern.test(this.text);


### PR DESCRIPTION
## What's included?
The CPS email warning should now show whenever the user enters an email address ending @cps.gov.uk

Previously if a dot was included in the name part of the email then the message didn't show up.

For example the warning did not show for some.thing@cps.gov.uk

Closes #1110 

## Who should test?
✅ Product owner
✅ Developers

## How to test?
Use the sign up form and check that a CPS warning message appears if you enter any of the following email addresses:

something@cps.gov.uk
some.thing@cps.gov.uk

Bonus: try some other variants where you would expect the CPS warning message to either appear or not appear

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work


---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
