### PR TITLE
Feature/1118 Bespoke question for Exercise 187 First Tier Tribunal Medical Member (SEC)

### DIFF
--- a/src/assets/welsh.json
+++ b/src/assets/welsh.json
@@ -5,6 +5,7 @@
   "Eligibility Check": "Gwiriad Cymhwysedd",
   "Eligibility Pass": "Pàs Cymhwysedd",
   "Apply": "Gwneud cais",
+  "Apply in Welsh": "Gwneud cais yn Gymraeg",
   "Apply for a role task list": "Gwneud cais am restr tasgau rôl",
   "Check if you meet the nationality requirement": "GWIRIWCH a ydych YN bodloni'r gofyniad cenedligrwydd",
   "Citizenship": "Dinasyddiaeth",

--- a/src/components/Form/CheckboxGroup.vue
+++ b/src/components/Form/CheckboxGroup.vue
@@ -15,7 +15,7 @@
       >
         {{ label }}
         <span
-          v-if="!required"
+          v-if="!required && !optionalHidden"
           class="govuk-label"
           style="margin-bottom: 0;"
         >

--- a/src/components/Form/FormField.vue
+++ b/src/components/Form/FormField.vue
@@ -34,6 +34,10 @@ export default {
     required: {
       type: Boolean,
     },
+    optionalHidden: { // if true, the optional text will be hidden
+      type: Boolean,
+      default: false,
+    },
     minLength: {
       type: Number,
       default: 0,

--- a/src/router.js
+++ b/src/router.js
@@ -77,6 +77,7 @@ import Review from '@/views/Apply/FinalCheck/Review.vue';
 import Confirmation from '@/views/Apply/FinalCheck/Confirmation.vue';
 import AdditionalInformation from '@/views/Apply/AdditionalInformation.vue';
 import CommissionerConflicts from '@/views/Apply/CommissionerConflicts.vue';
+import ResignationFromDWP from '@/views/Apply/ResignationFromDWP.vue';
 
 // Character Checks
 import CharacterChecks from '@/views/Apply/CharacterChecks/CharacterChecks.vue';
@@ -387,6 +388,16 @@ const routes = [
         meta: {
           requiresAuth: true,
           title: 'Give Leadership Judge details',
+          isMultilanguage: true,
+        },
+      },
+      {
+        path: 'resignation-from-dwp',
+        component: ResignationFromDWP,
+        name: 'resignation-from-dwp',
+        meta: {
+          requiresAuth: true,
+          title: 'Resignation from DWP',
           isMultilanguage: true,
         },
       },

--- a/src/views/Apply/ApplyMixIn.js
+++ b/src/views/Apply/ApplyMixIn.js
@@ -44,6 +44,11 @@ export default {
       // [develop, staging, prod]
       return ['JAC00507','JAC00660','JAC00164'].includes(this.vacancy.referenceNumber);
     },
+    isJAC00187() {
+      if (!this.vacancy) { return false; }
+      // [develop, staging, prod]
+      return ['JAC00696', 'JAC00695', 'JAC00187'].includes(this.vacancy.referenceNumber);
+    },
     vacancy() {
       return this.$store.state.vacancy.record;
     },

--- a/src/views/Apply/FinalCheck/Review.vue
+++ b/src/views/Apply/FinalCheck/Review.vue
@@ -773,7 +773,8 @@
                 class="govuk-summary-list__row"
               >
                 <dt class="govuk-summary-list__key">
-                  I will resign my post at DWP if recommended for this post.
+                  Please note, if you work for the DWP and are recommended for appointment as a Fee-paid Medical Member, you will be required to resign from your post in order to take up appointment.
+                  Please tick to confirm that you have read this.
                 </dt>
                 <dd
                   class="govuk-summary-list__value"

--- a/src/views/Apply/FinalCheck/Review.vue
+++ b/src/views/Apply/FinalCheck/Review.vue
@@ -780,7 +780,7 @@
                   class="govuk-summary-list__value"
                   data-welsh="can-give-reasonable-los"
                 >
-                  {{ $filters.toYesNo(application.resignationFromDWP.agreedToResign) }}
+                  {{ $filters.toYesNo(application.resignationFromDWP.isConfirmed) }}
                 </dd>
               </div>
             </dl>

--- a/src/views/Apply/FinalCheck/Review.vue
+++ b/src/views/Apply/FinalCheck/Review.vue
@@ -739,6 +739,52 @@
             </dl>
           </div>
 
+          <div v-if="isJAC00187">
+            <div class="govuk-!-margin-top-9">
+              <h2
+                class="govuk-heading-l"
+                style="display:inline-block;"
+              >
+                Resignation from the Department for Work and Pensions (DWP)
+              </h2>
+              <RouterLink
+                v-if="canEdit"
+                class="govuk-link govuk-body-m change-link"
+                style="display:inline-block;"
+                :to="{name: 'resignation-from-dwp'}"
+              >
+                Change
+              </RouterLink>
+            </div>
+            <dl class="govuk-summary-list govuk-!-margin-bottom-8">
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">
+                  Do you currently work at the Department for Work and Pensions (DWP)?
+                </dt>
+                <dd
+                  class="govuk-summary-list__value"
+                  data-welsh="can-give-reasonable-los"
+                >
+                  {{ $filters.toYesNo(application.resignationFromDWP.workingAtDWP) }}
+                </dd>
+              </div>
+              <div
+                v-if="application.resignationFromDWP.workingAtDWP"
+                class="govuk-summary-list__row"
+              >
+                <dt class="govuk-summary-list__key">
+                  I will resign my post at DWP if recommended for this post.
+                </dt>
+                <dd
+                  class="govuk-summary-list__value"
+                  data-welsh="can-give-reasonable-los"
+                >
+                  {{ $filters.toYesNo(application.resignationFromDWP.agreedToResign) }}
+                </dd>
+              </div>
+            </dl>
+          </div>
+
           <div v-if="applicationParts.additionalInfo">
             <div
               class="govuk-!-margin-top-9"

--- a/src/views/Apply/QualificationsAndExperience/RelevantExperience.vue
+++ b/src/views/Apply/QualificationsAndExperience/RelevantExperience.vue
@@ -10,6 +10,13 @@
           Relevant experience
         </h1>
 
+        <p
+          v-if="isJAC00187"
+          class="govuk-body-l"
+        >
+          Please detail your career history in reverse chronological order.
+        </p>
+
         <ErrorSummary
           :errors="errors"
           :show-save-button="true"

--- a/src/views/Apply/QualificationsAndExperience/RelevantMemberships.vue
+++ b/src/views/Apply/QualificationsAndExperience/RelevantMemberships.vue
@@ -17,6 +17,7 @@
           id="professional-memberships"
           v-model="formData.professionalMemberships"
           label="What professional memberships do you have?"
+          :required="isJAC00187"
         >
           <CheckboxItem
             v-if="showMembershipOption('chartered-association-of-building-engineers')"

--- a/src/views/Apply/QualificationsAndExperience/RelevantMemberships.vue
+++ b/src/views/Apply/QualificationsAndExperience/RelevantMemberships.vue
@@ -17,6 +17,7 @@
           id="professional-memberships"
           v-model="formData.professionalMemberships"
           label="What professional memberships do you have?"
+          :optional-hidden="isJAC00187"
         >
           <CheckboxItem
             v-if="showMembershipOption('chartered-association-of-building-engineers')"

--- a/src/views/Apply/QualificationsAndExperience/RelevantMemberships.vue
+++ b/src/views/Apply/QualificationsAndExperience/RelevantMemberships.vue
@@ -17,7 +17,6 @@
           id="professional-memberships"
           v-model="formData.professionalMemberships"
           label="What professional memberships do you have?"
-          :required="isJAC00187"
         >
           <CheckboxItem
             v-if="showMembershipOption('chartered-association-of-building-engineers')"

--- a/src/views/Apply/ResignationFromDWP.vue
+++ b/src/views/Apply/ResignationFromDWP.vue
@@ -32,9 +32,11 @@
           v-if="formData.resignationFromDWP.workingAtDWP"
           id="resign-from-dwp"
           v-model="formData.resignationFromDWP.agreedToResign"
+          multiline-label
         >
           <span>
-            I will resign my post at DWP if recommended for this post.
+            Please note, if you work for the DWP and are recommended for appointment as a Fee-paid Medical Member, you will be required to resign from your post in order to take up appointment.
+            Please tick to confirm that you have read this.
           </span>
         </Checkbox>
 

--- a/src/views/Apply/ResignationFromDWP.vue
+++ b/src/views/Apply/ResignationFromDWP.vue
@@ -1,0 +1,115 @@
+<template>
+  <div class="govuk-grid-row">
+    <form
+      ref="formRef"
+      @submit.prevent="save"
+    >
+      <div class="govuk-grid-column-two-thirds">
+        <BackLink />
+        <h1 class="govuk-heading-xl">
+          Resignation from the Department for Work and Pensions (DWP)
+        </h1>
+
+        <ErrorSummary :errors="errors" />
+
+        <RadioGroup
+          id="working-at-dwp"
+          v-model="formData.resignationFromDWP.workingAtDWP"
+          required
+          label="Do you currently work at the Department for Work and Pensions (DWP)?"
+        >
+          <RadioItem
+            :value="true"
+            label="Yes"
+          />
+          <RadioItem
+            :value="false"
+            label="No"
+          />
+        </RadioGroup>
+
+        <Checkbox
+          v-if="formData.resignationFromDWP.workingAtDWP"
+          id="resign-from-dwp"
+          v-model="formData.resignationFromDWP.agreedToResign"
+        >
+          <span>
+            I will resign my post at DWP if recommended for this post.
+          </span>
+        </Checkbox>
+
+        <button
+          :disabled="!canSave(formId)"
+          class="govuk-button info-btn--personal-details--save-and-continue"
+        >
+          Save and continue
+        </button>
+      </div>
+    </form>
+  </div>
+</template>
+
+<script>
+import Form from '@/components/Form/Form.vue';
+import ErrorSummary from '@/components/Form/ErrorSummary.vue';
+import ApplyMixIn from './ApplyMixIn';
+import RadioGroup from '@/components/Form/RadioGroup.vue';
+import RadioItem from '@/components/Form/RadioItem.vue';
+import Checkbox from '@/components/Form/Checkbox.vue';
+import BackLink from '@/components/BackLink.vue';
+
+export default {
+  name: 'ResignationFromDWP',
+  components: {
+    BackLink,
+    RadioGroup,
+    RadioItem,
+    Checkbox,
+    ErrorSummary,
+  },
+  extends: Form,
+  mixins: [ApplyMixIn],
+  data() {
+    const defaults = {
+      resignationFromDWP: {
+        workingAtDWP: null,
+        agreedToResign: null,
+      },
+      progress: {},
+    };
+    const formData = { ...defaults };
+    const data = this.$store.getters['application/data'](defaults);
+    if (data.resignationFromDWP) {
+      formData.resignationFromDWP = data.resignationFromDWP;
+    }
+    if (data.progress) {
+      formData.progress = data.progress;
+    }
+    return {
+      formId: 'resignationFromDWP',
+      formData,
+    };
+  },
+  methods: {
+    isFormValid() {
+      if (this.formData.resignationFromDWP.workingAtDWP === true) {
+        if (!this.formData.resignationFromDWP.agreedToResign) {
+          this.errors.push({ id: 'error', message: 'Please check all boxes to continue' });
+        }
+        return this.formData.resignationFromDWP.agreedToResign;
+      } else if (this.formData.resignationFromDWP.workingAtDWP === false) {
+        return true;
+      }
+      return false;
+    },
+    async save() {
+      this.validate();
+      if (this.isValid() && this.isFormValid()) {
+        this.formData.progress[this.formId] = true;
+        await this.$store.dispatch('application/save', this.formData);
+        this.$router.push({ name: 'task-list' });
+      }
+    },
+  },
+};
+</script>

--- a/src/views/Apply/ResignationFromDWP.vue
+++ b/src/views/Apply/ResignationFromDWP.vue
@@ -31,7 +31,7 @@
         <Checkbox
           v-if="formData.resignationFromDWP.workingAtDWP"
           id="resign-from-dwp"
-          v-model="formData.resignationFromDWP.agreedToResign"
+          v-model="formData.resignationFromDWP.isConfirmed"
           multiline-label
         >
           <span>
@@ -75,7 +75,7 @@ export default {
     const defaults = {
       resignationFromDWP: {
         workingAtDWP: null,
-        agreedToResign: null,
+        isConfirmed: null,
       },
       progress: {},
     };
@@ -95,10 +95,10 @@ export default {
   methods: {
     isFormValid() {
       if (this.formData.resignationFromDWP.workingAtDWP === true) {
-        if (!this.formData.resignationFromDWP.agreedToResign) {
+        if (!this.formData.resignationFromDWP.isConfirmed) {
           this.errors.push({ id: 'error', message: 'Please check all boxes to continue' });
         }
-        return this.formData.resignationFromDWP.agreedToResign;
+        return this.formData.resignationFromDWP.isConfirmed;
       } else if (this.formData.resignationFromDWP.workingAtDWP === false) {
         return true;
       }

--- a/src/views/Apply/TaskList.vue
+++ b/src/views/Apply/TaskList.vue
@@ -208,6 +208,12 @@
           title="Additional Information"
         >
           <Task
+            v-if="isJAC00187"
+            id="resignation-from-dwp"
+            title="Resignation from the Department for Work and Pensions (DWP)"
+            :done="applicationProgress.resignationFromDWP"
+          />
+          <Task
             v-if="applicationParts.additionalInfo"
             id="additional-information"
             title="How did you hear about the vacancy?"
@@ -225,7 +231,7 @@
       </TaskList>
 
       <button
-        :disabled="!canApply"
+        :disabled="!canApply || (isJAC00187 && !applicationProgress.resignationFromDWP)"
         class="govuk-button info-btn--task-list--review-application"
         @click="reviewApplication"
       >


### PR DESCRIPTION
## What's included?
Closes #1118 

For Exercise 187 only:
- Add the hard-coded section "Resignation from the Department for Work and Pensions (DWP)".

    ![image](https://github.com/jac-uk/apply/assets/79906532/95bb0ae7-b332-4644-81d3-48b12e5e7f5a)

- Remove "optional" text under "Relevant memberships" section.

    ![image](https://github.com/jac-uk/apply/assets/79906532/98b976b1-3932-4c76-b93f-88c9a65a29d2)

- Add "Please detail your career history in reverse chronological order." under "Relevant experience".

    ![image](https://github.com/jac-uk/apply/assets/79906532/a306c812-6fde-4c87-a30a-af439aec6824)


## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Example vacancy: https://jac-apply-develop--pr1119-feature-1118-bespoke-0jkosmhw.web.app/vacancy/09zuw8tcILdrH2DJZA2g/

Steps:
1. Apply for the vacancy "187 First-tier Tribunal Medical Members SEC".
2. Check if "Resignation from the Department for Work and Pensions (DWP)" is in the task list.
3. Check if you can complete "Resignation from the Department for Work and Pensions (DWP)".
4. Check if the "optional" text is removed under "Relevant memberships" section. 
5. Check if the text "Please detail your career history in reverse chronological order." displays under "Relevant experience".
6. Complete the application form and check if the answers to "Resignation from the Department for Work and Pensions (DWP)" display on the review page.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Demo:

https://github.com/jac-uk/apply/assets/79906532/c76909a9-353e-4ff7-a784-459bb04928c3

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
