### PR TITLE
#1126 Bugfix: external adverts should not display blank screen

### DIFF
--- a/src/views/Vacancy/VacancyDetails.vue
+++ b/src/views/Vacancy/VacancyDetails.vue
@@ -138,7 +138,10 @@
           >{{ vacancy.exerciseMailbox }}</a>
         </p>
 
-        <div class="govuk-warning-text">
+        <div 
+          v-if="showApplyButton && isVacancyOpen && !vacancy.inviteOnly"
+          class="govuk-warning-text"
+        >
           <span
             class="govuk-warning-text__icon"
             aria-hidden="true"
@@ -363,7 +366,6 @@ import exerciseTimeline from '@/helpers/Timeline/exerciseTimeline';
 import DownloadLink from '@/components/DownloadLink.vue';
 import { ADVERT_TYPES, LANGUAGES } from '@/helpers/constants';
 import CustomHTML from '@/components/CustomHTML.vue';
-import _has from 'lodash/has';
 
 export default {
   name: 'VacancyDetails',
@@ -409,7 +411,7 @@ export default {
       return this.$store.state.vacancy.record;
     },
     hasDownloads() {
-      return _has(this.vacancy, 'downloads') && Object.keys(this.vacancy.downloads).length > 0;
+      return this.vacancy && this.vacancy.downloads && Object.values(this.vacancy.downloads).length > 0;
     },
     user() {
       return this.$store.state.auth.currentUser;


### PR DESCRIPTION
## What's included?
Fixes #1126 

## Who should test?
✅ Product owner
✅ Developers

## How to test?

**View the following vacancy details page on production**
https://apply.judicialappointments.digital/vacancy/lQlCzxeR4Q5FQxCcg7D6/
Observe that the page is empty

**View the same vacancy details page on production with this fix**
https://apply-prod--1126-zvwiz4fq.web.app/vacancy/lQlCzxeR4Q5FQxCcg7D6/
Observe that the page displays correctly

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context

**Before**
<img width="807" alt="image" src="https://github.com/jac-uk/apply/assets/8524401/f70312c5-e7e6-479b-b588-62090ddd5ad1">

**After**
<img width="1208" alt="image" src="https://github.com/jac-uk/apply/assets/8524401/f2963b10-953e-4205-aec4-ee7f93babe81">
