### PR TITLE
Bugfix: Commissioner conflicts should be marked as DONE when form completed

### DIFF
--- a/src/views/Apply/CommissionerConflicts.vue
+++ b/src/views/Apply/CommissionerConflicts.vue
@@ -156,11 +156,11 @@ export default {
     async save() {
       this.validate();
       if (this.isValid() && this.isFormValid()) {
+        this.formData.progress[this.formId] = true;
         await this.$store.dispatch('application/save', this.formData);
         if (this.customSave) {
           await this.customSave();
         } else {
-          this.formData.progress[this.formId] = true;
           this.$router.push({ name: 'task-list' });
         }
       }


### PR DESCRIPTION
## What's included?

Urgent bugfix as candidates are unable to submit their applications due to commissioner conflicts form not being marked as done.

Closes #1130 

## Who should test?
✅ Product owner
✅ Developers

## How to test?

Start an application for any open exercise.

Fill in the commissioner conflicts form and submit it.

Notice that the commissioner conflicts task is marked as DONE  (previously it was not)

Check that you can complete and submit the whole application form (to ensure there are no other bugs)

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
