### PR TITLE
Bugfix/Issue 190 Self assessment extraction

### DIFF
--- a/src/components/Form/TextareaInput.vue
+++ b/src/components/Form/TextareaInput.vue
@@ -26,6 +26,7 @@
       name="word-count"
       :rows="rows"
       :disabled="disabled"
+      :style="style"
       @keydown="handleLimit($event)"
       @keyup="handleLimit($event)"
       @change="validate"
@@ -82,6 +83,10 @@ export default {
     disabled: {
       default: false,
       type: Boolean,
+    },
+    style: {
+      default: '',
+      type: String,
     },
   },
   emits: ['update:modelValue'],

--- a/src/components/Form/TextareaInput.vue
+++ b/src/components/Form/TextareaInput.vue
@@ -85,8 +85,8 @@ export default {
       type: Boolean,
     },
     style: {
-      default: '',
-      type: String,
+      default: () => {},
+      type: Object,
     },
   },
   emits: ['update:modelValue'],

--- a/src/views/Apply/Assessments/DataConfirmation.vue
+++ b/src/views/Apply/Assessments/DataConfirmation.vue
@@ -33,6 +33,7 @@
           v-model="formData.uploadedSelfAssessmentContent[i]"
           :label="`Statement content section ${i + 1}`"
           :word-limit="wordLimit"
+          style="white-space: pre-line;"
         />
 
         <button

--- a/src/views/Apply/Assessments/DataConfirmation.vue
+++ b/src/views/Apply/Assessments/DataConfirmation.vue
@@ -24,16 +24,15 @@
           Re-upload document
         </RouterLink>
 
-        <component
-          :is="components.TextareaInput"
+        <TextareaInput
           v-for="(section, i) in selfAssessmentSections"
-          id="suitability-statement-text"
+          :id="`self-assessment-answer-${i}`"
           :key="i"
-          :ref="`StatementInputRef${i}`"
           v-model="formData.uploadedSelfAssessmentContent[i]"
           :label="`${i + 1}. ${section.question}`"
           :word-limit="section.wordLimit"
-          style="white-space: pre-line;"
+          :style="{ 'white-space': 'pre-line' }"
+          required
         />
 
         <button
@@ -54,7 +53,6 @@ import { logEvent } from '@/helpers/logEvent';
 import ErrorSummary from '@/components/Form/ErrorSummary';
 import TextareaInput from '@/components/Form/TextareaInput';
 import BackLink from '@/components/BackLink';
-import { shallowRef } from 'vue';
 
 export default {
   //I tried to leave this component open for refactor so
@@ -64,6 +62,7 @@ export default {
   components: {
     ErrorSummary,
     BackLink,
+    TextareaInput,
   },
   extends: Form,
   mixins: [ApplyMixIn],
@@ -77,10 +76,7 @@ export default {
     return {
       formId: 'selfAssessmentCompetencies',
       formData: formData,
-      statementType: 'statement-of-suitability-with-competencies',
-      components: shallowRef({
-        TextareaInput,
-      }),
+      statementType: 'self-assessment-with-competencies',
     };
   },
   computed: {

--- a/src/views/Apply/Assessments/DataConfirmation.vue
+++ b/src/views/Apply/Assessments/DataConfirmation.vue
@@ -26,13 +26,13 @@
 
         <component
           :is="components.TextareaInput"
-          v-for="(wordLimit, i) in wordLimits"
+          v-for="(section, i) in selfAssessmentSections"
           id="suitability-statement-text"
           :key="i"
           :ref="`StatementInputRef${i}`"
           v-model="formData.uploadedSelfAssessmentContent[i]"
-          :label="`Statement content section ${i + 1}`"
-          :word-limit="wordLimit"
+          :label="`${i + 1}. ${section.question}`"
+          :word-limit="section.wordLimit"
           style="white-space: pre-line;"
         />
 
@@ -84,15 +84,12 @@ export default {
     };
   },
   computed: {
-    wordLimits() {
-      return this.vacancy.selfAssessmentWordLimits.map(section => section.wordLimit);
-    },
     selfAssessmentSections() {
-      return this.wordLimits.length;
+      return this.vacancy.selfAssessmentWordLimits || [];
     },
   },
   created() {
-    this.formData.uploadedSelfAssessmentContent = this.processArrayWithLimit(this.formData.uploadedSelfAssessmentContent, this.selfAssessmentSections);
+    this.formData.uploadedSelfAssessmentContent = this.processArrayWithLimit(this.formData.uploadedSelfAssessmentContent, this.selfAssessmentSections.length);
   },
   methods: {
     processArrayWithLimit(stringsArray, limit) {

--- a/src/views/Apply/Assessments/SelfAssessmentCompetencies.vue
+++ b/src/views/Apply/Assessments/SelfAssessmentCompetencies.vue
@@ -222,7 +222,11 @@ export default {
       }
 
       try {
-        const response = await functions.httpsCallable('extractDocumentContent')({ templatePath: this.templatePath, documentPath: this.documentPath });
+        const response = await functions.httpsCallable('extractDocumentContent')({
+          templatePath: this.templatePath,
+          documentPath: this.documentPath,
+          questions: this.vacancy.selfAssessmentWordLimits.map(section => section.question ? section.question.trim() : ''),
+        });
         await this.$store.dispatch('application/save', {
           uploadedSelfAssessmentContent: response.data.result,
           uploadedSelfAssessment: this.formData.uploadedSelfAssessment,

--- a/src/views/Apply/FinalCheck/Review.vue
+++ b/src/views/Apply/FinalCheck/Review.vue
@@ -690,6 +690,7 @@
                     <div
                       v-for="(answer, i) in application.uploadedSelfAssessmentContent"
                       :key="i"
+                      style="white-space: pre-line;"
                     >
                       {{ answer }}
                       <hr>

--- a/src/views/Apply/FinalCheck/Review.vue
+++ b/src/views/Apply/FinalCheck/Review.vue
@@ -684,16 +684,18 @@
                   Self assessment content
                 </dt>
                 <dd class="govuk-summary-list__value">
-                  <div
-                    v-if="application.uploadedSelfAssessment"
-                  >
+                  <div v-if="selfAssessmentSections">
                     <div
-                      v-for="(answer, i) in application.uploadedSelfAssessmentContent"
+                      v-for="(section, i) in selfAssessmentSections"
                       :key="i"
                       style="white-space: pre-line;"
                     >
-                      {{ answer }}
-                      <hr>
+                      <strong>
+                        {{ `${i + 1}. ${section.question}` }}
+                      </strong>
+                      <br>
+                      {{ application.uploadedSelfAssessmentContent[i] || '' }}
+                      <hr v-if="i !== selfAssessmentSections.length - 1">
                     </div>
                   </div>
                   <span v-else>Not yet received</span>
@@ -1209,6 +1211,9 @@ export default {
     },
     hasEmploymentGaps() {
       return this.applicationParts.employmentGaps || (this.isApplicationVersionGreaterThan2 && this.applicationParts.postQualificationWorkExperience);
+    },
+    selfAssessmentSections() {
+      return this.vacancy.selfAssessmentWordLimits || [];
     },
   },
   methods: {


### PR DESCRIPTION
## What's included?

Mentions [issue 190](https://github.com/jac-uk/ticketing-system/issues/190)

- Show the question text in the review of the self-assessment.
  
  ![image](https://github.com/jac-uk/apply/assets/79906532/99c268f3-c067-479f-a11e-560e16daea7c)

  ![image](https://github.com/jac-uk/apply/assets/79906532/e66ac5c5-ce0a-4e03-ba36-24b845e34739)

- Show line breaks on the extracted self-assessment content.

## Who should test?
✅ Product owner
✅ Developers

## How to test?
- Example vacancy: https://jac-apply-develop--pr1138-bugfix-issue-190-sel-a9ov50fs.web.app/vacancy/nrNvxQxa38XkFrE0ps5j/

- Example self-assessment file:
[self-assessment-example.docx](https://github.com/jac-uk/apply/files/14268636/self-assessment-example.docx)

Steps:
1. Apply for the vacancy.
2. Go to "Self assessment with competencies" and upload the self-assessment file. 
3. Click "Save and continue" and check if the questions and answers are extracted correctly with line breaks.
4. Go to the Review page and check if the self-assessment content shows correctly with line breaks.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Demo:

https://github.com/jac-uk/apply/assets/79906532/53540a4d-4468-4025-8613-0f0c2bb47683

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
