### PR TITLE
1147 welsh translation updates for JAC00193

### DIFF
--- a/src/assets/welsh.json
+++ b/src/assets/welsh.json
@@ -744,5 +744,10 @@
   "You have indicated that you have": "Rydych wedi nodi bod gennych gyfanswm o",
   "sitting days in total.": "diwrnod eistedd.",
   "As you have indicated you have less than": "Gan eich bod wedi nodi bod gennych lai na",
-  "sitting days across all judicial and/or quasi-judicial appointments, please provide details of how you have acquired the necessary skills for this role in some other significant way.": "o ddiwrnodau eistedd ar draws pob penodiad barnwrol a/neu led-farnwrol, rhowch fanylion am sut rydych wedi ennill y sgiliau angenrheidiol ar gyfer y rôl hon mewn rhyw ffordd arwyddocaol arall."
+  "sitting days across all judicial and/or quasi-judicial appointments, please provide details of how you have acquired the necessary skills for this role in some other significant way.": "o ddiwrnodau eistedd ar draws pob penodiad barnwrol a/neu led-farnwrol, rhowch fanylion am sut rydych wedi ennill y sgiliau angenrheidiol ar gyfer y rôl hon mewn rhyw ffordd arwyddocaol arall.",
+  "Please enter at least one qualification.": "Nodwch o leiaf un cymhwyster.",
+  "If you were engaged in law related activities during this time, please select all the relevant tasks. These are defined in the": "Os oeddech chi’n ymwneud â gweithgareddau sy’n ymwneud â’r gyfraith yn ystod y cyfnod hwn, dewiswch yr holl dasgau perthnasol. Mae’r rhain wedi’u diffinio yn",
+  "This post requires the successful candidate to be able to speak, read and write Welsh. Are you able to do this to a standard which will enable you to conduct the business of the Tribunal in Welsh?" : "Mae’r swydd hon yn gofyn i’r ymgeisydd llwyddiannus allu siarad, darllen ac ysgrifennu Cymraeg. Ydych chi’n gallu gwneud hyn i safon a fydd yn eich galluogi i gynnal busnes y Tribiwnlys yn Gymraeg?",
+  "If yes, there is no need to provide further information in the text box. Please simply add ‘Yes’.": "Os ydych chi, nid oes angen darparu rhagor o wybodaeth yn y blwch testun. Nodwch ‘Ydw’.",
+  "Acceptable file types: docx, doc, odt, txt, fodt": "Mathau derbyniol o ffeiliau: docx, doc, odt, txt, fodt"
 }

--- a/src/assets/welsh.json
+++ b/src/assets/welsh.json
@@ -749,5 +749,6 @@
   "If you were engaged in law related activities during this time, please select all the relevant tasks. These are defined in the": "Os oeddech chi’n ymwneud â gweithgareddau sy’n ymwneud â’r gyfraith yn ystod y cyfnod hwn, dewiswch yr holl dasgau perthnasol. Mae’r rhain wedi’u diffinio yn",
   "This post requires the successful candidate to be able to speak, read and write Welsh. Are you able to do this to a standard which will enable you to conduct the business of the Tribunal in Welsh?" : "Mae’r swydd hon yn gofyn i’r ymgeisydd llwyddiannus allu siarad, darllen ac ysgrifennu Cymraeg. Ydych chi’n gallu gwneud hyn i safon a fydd yn eich galluogi i gynnal busnes y Tribiwnlys yn Gymraeg?",
   "If yes, there is no need to provide further information in the text box. Please simply add ‘Yes’.": "Os ydych chi, nid oes angen darparu rhagor o wybodaeth yn y blwch testun. Nodwch ‘Ydw’.",
-  "Acceptable file types: docx, doc, odt, txt, fodt": "Mathau derbyniol o ffeiliau: docx, doc, odt, txt, fodt"
+  "Acceptable file types: docx, doc, odt, txt, fodt": "Mathau derbyniol o ffeiliau: docx, doc, odt, txt, fodt",
+  "Statutory Eligibility - Welsh language requirements": "Cymhwysedd Statudol - Gofynion o ran y Gymraeg"
 }


### PR DESCRIPTION
## What's included?
Closes #1147 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
- Apply vacancy of this preview link: https://jac-apply-develop--pr1148-feat-1147-welsh-tran-pduz76iq.web.app/vacancy/4XLFEASyR7M4EWNNBC3r/
- Sign in with test accounts
```
application-0001@jac-dummy-email.jac
application-0002@jac-dummy-email.jac
application-0003@jac-dummy-email.jac
application-0004@jac-dummy-email.jac
application-0005@jac-dummy-email.jac
application-0006@jac-dummy-email.jac
application-0007@jac-dummy-email.jac
application-0008@jac-dummy-email.jac
application-0009@jac-dummy-email.jac
# password: 1qazZAQ!1qaz
```
- Go into `Relevant qualifications`
    - Check Welsh translation updated
- Go into `Post qualification experience` section
    - Select `It is a gap in employment`, check the Welsh description of `Law-related tasks in this role`
- Go into `Statement of suitability` section
    - Check the Welsh description of `Statutory Eligibility - Welsh language requirements`
    - Check the Welsh translation of `Acceptable file types`
- Go into `Curriculum vitae (CV)` section
    - Check the Welsh translation of `Acceptable file types`
    
## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, notes etc.

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
