### PR TITLE
Bugfix/TS 237 Exercise Location in Welsh

### DIFF
--- a/src/views/Vacancy/VacancyDetails.vue
+++ b/src/views/Vacancy/VacancyDetails.vue
@@ -98,7 +98,10 @@
           </span>
         </p>
         <p v-if="vacancy.location && showLocation">
-          <span class="govuk-body govuk-!-font-weight-bold">Location:</span> <span class="govuk-body"> {{ vacancy.location }}</span>
+          <span class="govuk-body govuk-!-font-weight-bold">Location:</span>
+          <span class="govuk-body">
+            {{ language === LANGUAGES.WELSH ? vacancy.locationWelsh : vacancy.location }}
+          </span>
         </p>
         <p v-if="showAppointmentType">
           <span class="govuk-body govuk-!-font-weight-bold">
@@ -138,7 +141,7 @@
           >{{ vacancy.exerciseMailbox }}</a>
         </p>
 
-        <div 
+        <div
           v-if="showApplyButton && isVacancyOpen && !vacancy.inviteOnly"
           class="govuk-warning-text"
         >


### PR DESCRIPTION
## What's included?
Issue: [User Raised Issue BR_000047](https://github.com/jac-uk/ticketing-system/issues/237)

- Add location in Welsh to vacancy.

English:

![image](https://github.com/jac-uk/apply/assets/79906532/9c688d2f-d4cd-4ab8-a7bc-96aa5685ed77)

Welsh:

![image](https://github.com/jac-uk/apply/assets/79906532/27afe22e-02fc-4754-9f3e-2a05c3e5042c)


## Who should test?
✅ Product owner
✅ Developers

## How to test?
Example vacancy: https://jac-apply-develop--pr1150-bugfix-ts-237-exerci-5fx627fx.web.app/vacancy/cGgGaguvcdSVb7SsTD7Y/

1. Go to the vacancy details page.
2. Try to switch the language between English and Welsh.
3. Check if the "Location" displays correctly.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, notes etc.

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
