### PR TITLE
Bugfix/TS 243 Membership Royal Institute of Chartered Surveyors

### DIFF
--- a/src/helpers/vuexfireJAC.js
+++ b/src/helpers/vuexfireJAC.js
@@ -10,7 +10,12 @@ const firestoreAction = (action) => {
 
     const unbindFirestoreRef = (name) => {
       const unsubscribe = state[getUnsubscribeName(name)];
-      unsubscribe && unsubscribe();
+      // clear state
+      commit('set', { name, value: Array.isArray(state[name]) ? [] : null });
+      if (unsubscribe) {
+        unsubscribe();
+        commit('set', { name: getUnsubscribeName(name), value: null });
+      }
     };
 
     const bindFirestoreRef = (name, ref, options) => {

--- a/src/helpers/vuexfireJAC.js
+++ b/src/helpers/vuexfireJAC.js
@@ -10,10 +10,10 @@ const firestoreAction = (action) => {
 
     const unbindFirestoreRef = (name) => {
       const unsubscribe = state[getUnsubscribeName(name)];
-      // clear state
-      commit('set', { name, value: Array.isArray(state[name]) ? [] : null });
       if (unsubscribe) {
         unsubscribe();
+        // clear state
+        commit('set', { name, value: Array.isArray(state[name]) ? [] : null });
         commit('set', { name: getUnsubscribeName(name), value: null });
       }
     };

--- a/src/views/Apply/CharacterChecks/OtherProfessionalBodies.vue
+++ b/src/views/Apply/CharacterChecks/OtherProfessionalBodies.vue
@@ -386,14 +386,14 @@ export default {
           this.formData.royalCollegeOfPsychiatristsInformation = null;
         }
 
-        if (!this.formData.professionalMemberships.includes('royal-institution-of-chartered-surveyors')) {
+        if (!this.formData.professionalMemberships.includes('royal-institute-of-british-architects')) {
           this.formData.royalInstituteBritishArchitectsDate = null;
           this.formData.royalInstituteBritishArchitectsStatus = null;
           this.formData.royalInstituteBritishArchitectsNumber = null;
           this.formData.royalInstituteBritishArchitectsInformation = null;
         }
 
-        if (!this.formData.professionalMemberships.includes('royal-institute-of-british-architects')) {
+        if (!this.formData.professionalMemberships.includes('royal-institution-of-chartered-surveyors')) {
           this.formData.royalInstitutionCharteredSurveyorsDate = null;
           this.formData.royalInstitutionCharteredSurveyorsStatus = null;
           this.formData.royalInstitutionCharteredSurveyorsNumber = null;

--- a/src/views/Apply/Forms/Parts/CharacterChecks/OtherProfessionalBodies.vue
+++ b/src/views/Apply/Forms/Parts/CharacterChecks/OtherProfessionalBodies.vue
@@ -392,14 +392,14 @@ export default {
           this.formData.royalCollegeOfPsychiatristsInformation = null;
         }
 
-        if (!this.formData.professionalMemberships.includes('royal-institution-of-chartered-surveyors')) {
+        if (!this.formData.professionalMemberships.includes('royal-institute-of-british-architects')) {
           this.formData.royalInstituteBritishArchitectsDate = null;
           this.formData.royalInstituteBritishArchitectsStatus = null;
           this.formData.royalInstituteBritishArchitectsNumber = null;
           this.formData.royalInstituteBritishArchitectsInformation = null;
         }
 
-        if (!this.formData.professionalMemberships.includes('royal-institute-of-british-architects')) {
+        if (!this.formData.professionalMemberships.includes('royal-institution-of-chartered-surveyors')) {
           this.formData.royalInstitutionCharteredSurveyorsDate = null;
           this.formData.royalInstitutionCharteredSurveyorsStatus = null;
           this.formData.royalInstitutionCharteredSurveyorsNumber = null;


### PR DESCRIPTION
## What's included?
Issue: [User Raised Issue BR_000053#243](https://github.com/jac-uk/ticketing-system/issues/243)

- Fix the bug that the membership details of "Royal Institute of Chartered Surveyors" are not saved correctly in the character checks consent form.
- Clear the state value when dispatching unbind action.

## Who should test?
✅ Product owner
✅ Developers

## How to test?
Test users (password: 1qazZAQ!1qaz)
- application-0001@jac-dummy-email.jac
- application-0002@jac-dummy-email.jac

1. Login to the [apply site](https://jac-apply-develop--pr1152-bugfix-ts-243-member-4cxdy7o4.web.app/) with the emails above.
2. Find the application "JAC00760 First-tier Tribunal Valuer Members and Chairs (Property) COPY" in the applications page.
3. Click "Complete character checks consent form" to complete the character checks.
4. Check if the information on professional memberships is saved correctly.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Demo:

https://github.com/jac-uk/apply/assets/79906532/036bb6f1-38d8-465f-879e-e7c854acb912

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
