### PR TITLE
1056/existing application hide apply button

### DIFF
--- a/src/store/applications.js
+++ b/src/store/applications.js
@@ -9,13 +9,13 @@ const collectionRef = collection(firestore, collectionName);
 export default {
   namespaced: true,
   actions: {
-    bind: firestoreAction(({ bindFirestoreRef, rootState }) => {
+    bind: firestoreAction(async ({ bindFirestoreRef, rootState }) => {
       const firestoreRef = query(
         collectionRef,
         where('userId', '==', rootState.auth.currentUser.uid),
         limit(200)  // @TODO enable paging
       );
-      return bindFirestoreRef('records', firestoreRef, { serialize: vuexfireSerialize });
+      return await bindFirestoreRef('records', firestoreRef, { serialize: vuexfireSerialize });
     }),
     unbind: firestoreAction(({ unbindFirestoreRef }) => {
       return unbindFirestoreRef('records');

--- a/src/views/Vacancy/VacancyDetails.vue
+++ b/src/views/Vacancy/VacancyDetails.vue
@@ -134,7 +134,9 @@
           v-if="vacancy.exerciseMailbox"
           class="govuk-!-margin-bottom-6"
         >
-          <span class="govuk-body govuk-!-font-weight-bold">Contact: </span>
+          <span class="govuk-body govuk-!-font-weight-bold">
+            Contact:
+          </span>
           <a
             :href="`mailto:${vacancy.exerciseMailbox}?subject=Re:${vacancy.referenceNumber}`"
             class="govuk-body govuk-link"
@@ -466,6 +468,9 @@ export default {
     showDownload() {
       return this.advertType !== ADVERT_TYPES.BASIC && this.hasDownloads;
     },
+    candidateHasCompletedApplication() {
+      return this.records.filter(appl => appl.status === 'applied').map(appl => appl.exerciseId).includes(this.vacancy.id);
+    },
     candidateHasApplication() {
       return this.records.map(appl => appl.exerciseId).includes(this.vacancy.id);
     },
@@ -507,7 +512,8 @@ export default {
       this.$router.push({ name: 'eligibility' });
     },
     goToApplication() {
-      this.$router.push({ name: 'review', params: { id: this.vacancy.id } });
+      const page = this.candidateHasCompletedApplication ? 'review' : 'task-list';
+      this.$router.push({ name: page, params: { id: this.vacancy.id } });
     },
     onSideNavLinkClick(id) {
       if (this.$refs[id]) {

--- a/src/views/Vacancy/VacancyDetails.vue
+++ b/src/views/Vacancy/VacancyDetails.vue
@@ -380,9 +380,6 @@ import exerciseTimeline from '@/helpers/Timeline/exerciseTimeline';
 import DownloadLink from '@/components/DownloadLink.vue';
 import { ADVERT_TYPES, LANGUAGES } from '@/helpers/constants';
 import CustomHTML from '@/components/CustomHTML.vue';
-import {
-  mapState
-} from 'vuex';
 
 export default {
   name: 'VacancyDetails',
@@ -400,7 +397,6 @@ export default {
     };
   },
   computed: {
-    ...mapState('applications', ['records']),
     language() {
       return this.$store.state.application.language;
     },
@@ -427,6 +423,9 @@ export default {
     },
     vacancy () {
       return this.$store.state.vacancy.record;
+    },
+    applications () {
+      return this.$store.state.applications.records;
     },
     hasDownloads() {
       return this.vacancy && this.vacancy.downloads && Object.values(this.vacancy.downloads).length > 0;
@@ -469,10 +468,10 @@ export default {
       return this.advertType !== ADVERT_TYPES.BASIC && this.hasDownloads;
     },
     candidateHasCompletedApplication() {
-      return this.records.filter(appl => appl.status === 'applied').map(appl => appl.exerciseId).includes(this.vacancy.id);
+      return this.applications.filter(appl => appl.status === 'applied').map(appl => appl.exerciseId).includes(this.vacancy.id);
     },
     candidateHasApplication() {
-      return this.records.map(appl => appl.exerciseId).includes(this.vacancy.id);
+      return this.applications.map(appl => appl.exerciseId).includes(this.vacancy.id);
     },
     showApplyButton() {
       return this.advertTypeFull || this.advertType === ADVERT_TYPES.BASIC;

--- a/src/views/Vacancy/VacancyDetails.vue
+++ b/src/views/Vacancy/VacancyDetails.vue
@@ -177,7 +177,7 @@
             View Application
           </a>
           <a
-            v-if="vacancy.welshPosts && showApplyButton && isVacancyOpen && !vacancy.inviteOnly && enableApplyInWelsh && !candidateHasApplication"
+            v-else-if="vacancy.welshPosts && showApplyButton && isVacancyOpen && !vacancy.inviteOnly && enableApplyInWelsh"
             class="govuk-button info-link--vacancy-details--check-if-you-are-eligible-and-apply govuk-!-margin-left-4"
             data-module="govuk-button"
             style="margin-bottom: 0;"
@@ -491,7 +491,10 @@ export default {
     },
   },
   created() {
-    this.$store.dispatch('applications/bind');
+    if (this.$store.getters['auth/isSignedIn']){
+      this.$store.dispatch('applications/bind');
+    }
+
   },
   unmounted() {
     this.$store.dispatch('applications/unbind');


### PR DESCRIPTION
## What's included?
When on an advert page, apply button will change to "view application", once clicked sending users to either the review or tasklist pages depending on if an application has been submitted or not.

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Find the advert for an application you have applied to (vacancies > exercise)

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work


## Additional context
![image](https://github.com/jac-uk/apply/assets/44227249/76d8ee4b-c725-417d-a7e6-6be25916a5a5)

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
