### PR TITLE
Bugfix/1170 FirebaseError: Missing or insufficient permissions

### DIFF
--- a/src/store/logs.js
+++ b/src/store/logs.js
@@ -2,22 +2,20 @@ import { collection, doc, setDoc, serverTimestamp } from '@firebase/firestore';
 import { firestore } from '@/firebase';
 
 const collectionName = 'logs';
-const collectionRef = collection(firestore, collectionName);
 
 export default {
   namespaced: true,
   actions: {
     save: async (context, obj) => {
-      const ref = doc(collectionRef, obj.type);
-      // ref = ref.collection(obj.id).doc();
-      setDoc(
-          ref,
-          {
-            data: obj.data,
-            type: obj.type,
-            date: serverTimestamp(),
-          }
-      );
+      if (!obj || !obj.type || !obj.id || !obj.data) return;
+      // get subcollection reference
+      const collectionRef = collection(firestore, collectionName, obj.type, obj.id);
+      const ref = doc(collectionRef);
+      await setDoc(ref, {
+        data: obj.data,
+        type: obj.type,
+        date: serverTimestamp(),
+      });
     },
   },
 };


### PR DESCRIPTION
## What's included?
Closes #1170 

- Fix the Firestore syntax when querying a subcollection.

https://github.com/jac-uk/apply/assets/79906532/e6922f71-1ba2-4b65-acc1-d7bf97bd09c2

## Who should test?
✅ Product owner
✅ Developers

## How to test?

Sign in and check if there is no error in the browser console.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, notes etc.

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
