### PR TITLE
Limit format of SA template uploads to .docx

### DIFF
--- a/src/components/Form/FileUpload.vue
+++ b/src/components/Form/FileUpload.vue
@@ -107,6 +107,12 @@ export default {
         };
       },
     },
+    acceptableExtensions: {
+      type: Array,
+      default: () => {
+        return ['docx', 'doc', 'odt', 'txt', 'fodt'];
+      },
+    },
   },
   emits: ['update:modelValue'],
   data() {
@@ -114,7 +120,6 @@ export default {
       file: '',
       isReplacing: false,
       isUploading: false,
-      acceptableExtensions: ['docx', 'doc', 'odt', 'txt', 'fodt'],
       downloadUrl: null,
     };
   },

--- a/src/views/Apply/Assessments/SelfAssessmentCompetencies.vue
+++ b/src/views/Apply/Assessments/SelfAssessmentCompetencies.vue
@@ -114,6 +114,7 @@
           :path="uploadPath"
           label="Upload finished self assessment"
           required
+          :acceptable-extensions="['docx']"
         />
         <ActionButton
           :disabled="!canSave(formId)"


### PR DESCRIPTION
## What's included?
Describe the changes included in this pull request and highlight dependencies with other repos/tickets
Related to Admin ticket: https://app.zenhub.com/workspaces/platform-development-5ea838cd2aec471eb6d14139/issues/gh/jac-uk/admin/2391

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
- Apply this exercise: https://jac-apply-develop--pr1173-feat-admin-2391-limi-hx0hiq7r.web.app/vacancy/IUSNh8uyhmM3u4x7F8eC
- Sign-in with following accounts:
```
application-0001@jac-dummy-email.jac
application-0002@jac-dummy-email.jac
application-0003@jac-dummy-email.jac
application-0004@jac-dummy-email.jac
application-0005@jac-dummy-email.jac
application-0006@jac-dummy-email.jac
application-0007@jac-dummy-email.jac
application-0008@jac-dummy-email.jac
application-0009@jac-dummy-email.jac
password: 1qazZAQ!1qaz
```
- Upload self assessment file, is should only accept .docx files.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, notes etc.

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
