### PR TITLE
#1174 Mandate all fields on relevant qualifications section for legal exercises

### DIFF
--- a/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
+++ b/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
@@ -2,7 +2,7 @@
   <div class="govuk-grid-row">
     <form
       ref="formRef"
-      @submit.prevent="save"
+      @submit.prevent="saveAndValidate"
     >
       <div class="govuk-grid-column-two-thirds">
         <BackLink />
@@ -26,6 +26,7 @@
             :id="`applying-under-${vacancy.appliedSchedule}`"
             v-model="formData.applyingUnderSchedule2d"
             :label="`Are you applying under ${appliedSchedule}?`"
+            required
           >
             <span>
               <a
@@ -90,6 +91,7 @@
         <RepeatableFields
           v-model="formData.qualifications"
           :component="repeatableFields.Qualification"
+          required
         />
 
         <template v-if="notCompletedPupillage">
@@ -200,7 +202,7 @@ export default {
     },
   },
   methods: {
-    validate() {
+    async saveAndValidate() {
       if (this.notCompletedPupillage) {
         if (this.formData.uploadedExemptionCertificate === null && this.formData.uploadedPracticingCertificate === null) {
           this.$refs['practicing-certificate'].setError('Please provide a copy of your practicing and/or exemption certificate');
@@ -211,6 +213,7 @@ export default {
           this.$refs['exemption-certificate'].setError('');
         }
       }
+      this.save();
     },
   },
 };


### PR DESCRIPTION
## What's included?
Make all fields required for relevant qualifications.

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Use this link: https://jac-apply-develop--pr1176-feature-1174-require-dsk7fxia.web.app/

- Go to the Relevant Qualifications of an application
- Try to Save And Continue without filling in all of the fields
- Ensure you get an error message appearing for each of the fields you havent completed
- Press the button to Add Another and submit the form, ensuring you get erorrs for each section not filled in
- Specify a Barrister as the qualification and press Save And Continue without filling in al the sections. Ensure you see an errors for the missing certificates
- Once you have filled in all the fields and pressed Save And Continue ensure you section shows as Done in the task list page
- Click back into the Relevant Qualifications and try editing the answers again ensuring you get errors if you press Save And Continue with empty fields

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
