### PR TITLE
Launch date - Close date in welsh

### DIFF
--- a/src/views/Vacancy/VacancyDetails.vue
+++ b/src/views/Vacancy/VacancyDetails.vue
@@ -60,7 +60,7 @@
         <div v-if="!advertTypeFull">
           <p>
             <span class="govuk-body govuk-!-font-weight-bold">
-              Launch Date:
+              {{ language === LANGUAGES.WELSH ? 'Dyddiad lansio: ' : 'Launch Date: ' }}
             </span>
             <span
               v-if="vacancy.applicationOpenDate"
@@ -79,7 +79,9 @@
             <span
               class="govuk-body govuk-!-font-weight-bold"
             >
-              <span class="govuk-body govuk-!-font-weight-bold"> Closing Date: </span>
+              <span class="govuk-body govuk-!-font-weight-bold">
+                {{ language === LANGUAGES.WELSH ? 'Dyddiad cau: ' : 'Closing Date: ' }}
+              </span>
             </span>
             <span
               class="govuk-body"


### PR DESCRIPTION
## What's included?
Small oversight in welsh translation on advert page, open/close dates showing in english.

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
Describe the steps required to test & verify this change

Visit [this exercise](https://jac-apply-develop--pr1179-ts-319-welsh-open-cl-3aphdrqh.web.app/vacancy/Vs5E3BSpvzgLbmnzgDuh/) and switch between english and welsh translations of the page

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Before:
![image](https://github.com/jac-uk/apply/assets/44227249/6773b5dd-961f-4a28-a0de-7771d4f15cd3)
After:
![image](https://github.com/jac-uk/apply/assets/44227249/b9d4489c-0450-49b4-be22-3b164246019b)


---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
