### PR TITLE
1177 Candidates taken to Sign In page when already signed in

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -961,6 +961,13 @@ const routes = [
     meta: {
       title: 'Sign In',
     },
+    beforeEnter: (to, from, next) => {
+      const isSignedIn = store.getters['auth/isSignedIn'];
+      if (isSignedIn) {
+        return next({ name: 'vacancies' });
+      }
+      return next();
+    },
   },
   {
     path: '/sign-up',


### PR DESCRIPTION
## What's included?
Redirect the user to the home page if already signed in and try to go to the sign in page.

Closes #1177 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
- Go to: https://jac-apply-develop--pr1180-feature-1177-sign-in-th1kmm4t.web.app/
- Sign out if you are already signed in
- Click the link to sign in
- Sign ln
- Open a new tab in your browser
- Try to go to the sign in page
- You should get redirected to the vacancies page

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
