### PR TITLE
allow no legal qualification for s2-3

### DIFF
--- a/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
+++ b/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
@@ -91,7 +91,7 @@
         <RepeatableFields
           v-model="formData.qualifications"
           :component="repeatableFields.Qualification"
-          :show-no-legal="formData.applyingUnderSchedule2d"
+          :show-no-legal="formData.applyingUnderSchedule2d || formData.applyingUnderSchedule2Three"
           required
         />
 
@@ -204,6 +204,13 @@ export default {
   },
   watch: {
     'formData.applyingUnderSchedule2d': function(newVal, oldVal) {
+      if (oldVal === true && newVal === false) {
+        this.formData.qualifications.forEach((qual)=>{
+          qual.type = null;
+        });
+      }
+    },
+    'formData.applyingUnderSchedule2Three': function(newVal, oldVal) {
       if (oldVal === true && newVal === false) {
         this.formData.qualifications.forEach((qual)=>{
           qual.type = null;


### PR DESCRIPTION
## What's included?

Mirroring work for applying under s2d for s2-3

- Allow candidates to select 'none of the above' (no legal qualifications) when applying under s2-3.
- Clear answer regarding legal qualifications if s2-3 answer is changed.

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?

https://github.com/jac-uk/apply/assets/44227249/7852f293-e60e-49cc-b997-87ac6f2ac6e3

apply/X2tDg5AKt18xvzBRJFYW/relevant-qualifications

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
