### PR TITLE
Silence sass warns

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -19,6 +19,7 @@ export default defineConfig({
         additionalData: `
           @import "@/styles/_shared.scss";
         `,
+        quietDeps: true,
       },
     },
   },


### PR DESCRIPTION
## What's included?
- Suppresses issues relating to sass calculations as these [have not been and **will not be resolved** using the suggested solution here (quietDeps)](https://github.com/alphagov/govuk-frontend/pull/4983) within the gds 

## Who should test?
✅ Developers

## How to test?
Spin up locally and see no warnings.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Related permissions
Have permissions been considered for this functionality?
- No permission changes required
- Permissions have been added / updated. Details:

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_