### PR TITLE
Feature/1204 Mandate NINo field in Personal details section of Application form

### DIFF
--- a/src/views/Apply/AccountProfile/PersonalDetails.vue
+++ b/src/views/Apply/AccountProfile/PersonalDetails.vue
@@ -95,6 +95,7 @@
           hint="It’s on your National Insurance card, payslip or P60. For example, ‘QQ 12 34 56 C’."
           class="govuk-!-width-one-half"
           type="nino"
+          required
         />
 
         <RadioGroup


### PR DESCRIPTION
## What's included?
Closes #1204

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?

[Example vacancy](https://jac-apply-develop--pr1205-feature-1204-mandate-ypbfz6y4.web.app/vacancy/aD8YKYEYhQbPThjcaKsM/)

Steps:
1. Apply for the vacancy.
2. Go to the Personal details section.
3. Check if the field "National Insurance number" is mandatory.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, notes etc.

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
