### PR TITLE
Fix/apply 1178 optional working preferences questions

### DIFF
--- a/src/views/Apply/WorkingPreferences/AdditionalWorkingPreferences.vue
+++ b/src/views/Apply/WorkingPreferences/AdditionalWorkingPreferences.vue
@@ -63,7 +63,7 @@ import ApplyMixIn from '../ApplyMixIn';
 import SelectionInput from '@/components/SelectionInput/SelectionInput.vue';
 import QuestionInput from '@/components/Form/QuestionInput.vue';
 import BackLink from '@/components/BackLink.vue';
-import { filteredPreferences, tidyData, isVersion1 } from './workingPreferencesHelper';
+import { filteredPreferences, isAllRequiredFilled, tidyData, isVersion1 } from './workingPreferencesHelper';
 
 export default {
   name: 'AdditionalWorkingPreferences',
@@ -107,11 +107,7 @@ export default {
       if (this.isV1) {
         return this.v1FormData.length ===  this.filteredPreferences.length;
       } else {
-        if (this.filteredPreferences.length) {
-          return this.filteredPreferences.length === Object.keys(this.formData[this.formId]).length;
-        } else {
-          return this.formData[this.formId] ? true : false;
-        }
+        return isAllRequiredFilled(this.filteredPreferences, this.formData, this.formId);
       }
     },
   },

--- a/src/views/Apply/WorkingPreferences/JurisdictionPreferences.vue
+++ b/src/views/Apply/WorkingPreferences/JurisdictionPreferences.vue
@@ -57,7 +57,7 @@ import ApplyMixIn from '../ApplyMixIn';
 import SelectionInput from '@/components/SelectionInput/SelectionInput.vue';
 import QuestionInput from '@/components/Form/QuestionInput.vue';
 import BackLink from '@/components/BackLink.vue';
-import { isAllRequiredFilled, filteredPreferences, tidyData, isVersion1 } from './workingPreferencesHelper';
+import { isAllRequiredFilled, filteredPreferences, tidyData } from './workingPreferencesHelper';
 
 export default {
   name: 'JurisdictionPreferences',
@@ -86,7 +86,7 @@ export default {
       return filteredPreferences(this.vacancy, this.formData, this.formId);
     },
     isV1() {
-      return isVersion1(this.filteredPreferences);
+      return !!this.vacancy.jurisdictionQuestion;
     },
     formComplete() {
       if (this.isV1) {

--- a/src/views/Apply/WorkingPreferences/JurisdictionPreferences.vue
+++ b/src/views/Apply/WorkingPreferences/JurisdictionPreferences.vue
@@ -22,7 +22,7 @@
           :answers="vacancy.jurisdictionQuestionAnswers"
           :type="vacancy.jurisdictionQuestionType"
         />
-        
+
         <div v-else-if="filteredPreferences.length">
           <QuestionInput
             v-for="(item, itemIndex) in filteredPreferences"
@@ -57,7 +57,7 @@ import ApplyMixIn from '../ApplyMixIn';
 import SelectionInput from '@/components/SelectionInput/SelectionInput.vue';
 import QuestionInput from '@/components/Form/QuestionInput.vue';
 import BackLink from '@/components/BackLink.vue';
-import { filteredPreferences, tidyData } from './workingPreferencesHelper';
+import { isAllRequiredFilled, filteredPreferences, tidyData } from './workingPreferencesHelper';
 
 export default {
   name: 'JurisdictionPreferences',
@@ -86,11 +86,7 @@ export default {
       return filteredPreferences(this.vacancy, this.formData, this.formId);
     },
     formComplete() {
-      if (this.filteredPreferences.length) {
-        return this.filteredPreferences.length === Object.keys(this.formData[this.formId]).length;
-      } else {
-        return this.formData[this.formId] ? true : false;
-      }
+      return isAllRequiredFilled(this.filteredPreferences, this.formData, this.formId);
     },
   },
   methods: {

--- a/src/views/Apply/WorkingPreferences/JurisdictionPreferences.vue
+++ b/src/views/Apply/WorkingPreferences/JurisdictionPreferences.vue
@@ -57,7 +57,7 @@ import ApplyMixIn from '../ApplyMixIn';
 import SelectionInput from '@/components/SelectionInput/SelectionInput.vue';
 import QuestionInput from '@/components/Form/QuestionInput.vue';
 import BackLink from '@/components/BackLink.vue';
-import { isAllRequiredFilled, filteredPreferences, tidyData } from './workingPreferencesHelper';
+import { isAllRequiredFilled, filteredPreferences, tidyData, isVersion1 } from './workingPreferencesHelper';
 
 export default {
   name: 'JurisdictionPreferences',
@@ -85,8 +85,20 @@ export default {
     filteredPreferences() {
       return filteredPreferences(this.vacancy, this.formData, this.formId);
     },
+    isV1() {
+      return isVersion1(this.filteredPreferences);
+    },
     formComplete() {
-      return isAllRequiredFilled(this.filteredPreferences, this.formData, this.formId);
+      if (this.isV1) {
+        // version 1 all questions are mandatory
+        if (this.filteredPreferences.length) {
+          return this.filteredPreferences.length === Object.keys(this.formData[this.formId]).length;
+        } else {
+          return this.formData[this.formId] ? true : false;
+        }
+      } {
+        return isAllRequiredFilled(this.filteredPreferences, this.formData, this.formId);
+      }
     },
   },
   methods: {

--- a/src/views/Apply/WorkingPreferences/LocationPreferences.vue
+++ b/src/views/Apply/WorkingPreferences/LocationPreferences.vue
@@ -7,7 +7,7 @@
       <div class="govuk-grid-column-two-thirds">
         <BackLink />
         <h1 class="govuk-heading-xl">
-          Location preferences
+          Location preferences123
         </h1>
 
         <ErrorSummary
@@ -40,7 +40,7 @@
         </div>
 
         <button
-          :disabled="!canSave(formId)"
+          :disabled="!canSave(formId) || !formComplete"
           class="govuk-button info-btn--location-pref--save-and-continue"
         >
           Save and continue
@@ -57,7 +57,7 @@ import ApplyMixIn from '../ApplyMixIn';
 import SelectionInput from '@/components/SelectionInput/SelectionInput.vue';
 import QuestionInput from '@/components/Form/QuestionInput.vue';
 import BackLink from '@/components/BackLink.vue';
-import { filteredPreferences, tidyData } from './workingPreferencesHelper';
+import { isAllRequiredFilled, filteredPreferences, tidyData } from './workingPreferencesHelper';
 
 export default {
   name: 'LocationPreferences',
@@ -84,6 +84,9 @@ export default {
   computed: {
     filteredPreferences() {
       return filteredPreferences(this.vacancy, this.formData, this.formId);
+    },
+    formComplete() {
+      return isAllRequiredFilled(this.filteredPreferences, this.formData, this.formId);
     },
   },
   methods: {

--- a/src/views/Apply/WorkingPreferences/LocationPreferences.vue
+++ b/src/views/Apply/WorkingPreferences/LocationPreferences.vue
@@ -40,7 +40,7 @@
         </div>
 
         <button
-          :disabled="!canSave(formId) || !formComplete"
+          :disabled="disabledSave"
           class="govuk-button info-btn--location-pref--save-and-continue"
         >
           Save and continue
@@ -57,7 +57,7 @@ import ApplyMixIn from '../ApplyMixIn';
 import SelectionInput from '@/components/SelectionInput/SelectionInput.vue';
 import QuestionInput from '@/components/Form/QuestionInput.vue';
 import BackLink from '@/components/BackLink.vue';
-import { isAllRequiredFilled, filteredPreferences, tidyData, isVersion1 } from './workingPreferencesHelper';
+import { isAllRequiredFilled, filteredPreferences, tidyData } from './workingPreferencesHelper';
 
 export default {
   name: 'LocationPreferences',
@@ -86,14 +86,18 @@ export default {
       return filteredPreferences(this.vacancy, this.formData, this.formId);
     },
     isV1() {
-      return isVersion1(this.filteredPreferences);
+      return !!this.vacancy.locationQuestion;
     },
     formComplete() {
+      return isAllRequiredFilled(this.filteredPreferences, this.formData, this.formId);
+    },
+    disabledSave() {
+      // if v1 all location preference is optional
       if (this.isV1) {
-        // version 1 all questions are optional
-        return true;
+        return false;
       } else {
-        return isAllRequiredFilled(this.filteredPreferences, this.formData, this.formId);
+        // if v2 it should validate mandatory questions
+        return (!this.canSave(this.formId) || !this.formComplete);
       }
     },
   },

--- a/src/views/Apply/WorkingPreferences/LocationPreferences.vue
+++ b/src/views/Apply/WorkingPreferences/LocationPreferences.vue
@@ -57,7 +57,7 @@ import ApplyMixIn from '../ApplyMixIn';
 import SelectionInput from '@/components/SelectionInput/SelectionInput.vue';
 import QuestionInput from '@/components/Form/QuestionInput.vue';
 import BackLink from '@/components/BackLink.vue';
-import { isAllRequiredFilled, filteredPreferences, tidyData } from './workingPreferencesHelper';
+import { isAllRequiredFilled, filteredPreferences, tidyData, isVersion1 } from './workingPreferencesHelper';
 
 export default {
   name: 'LocationPreferences',
@@ -85,8 +85,16 @@ export default {
     filteredPreferences() {
       return filteredPreferences(this.vacancy, this.formData, this.formId);
     },
+    isV1() {
+      return isVersion1(this.filteredPreferences);
+    },
     formComplete() {
-      return isAllRequiredFilled(this.filteredPreferences, this.formData, this.formId);
+      if (this.isV1) {
+        // version 1 all questions are optional
+        return true;
+      } else {
+        return isAllRequiredFilled(this.filteredPreferences, this.formData, this.formId);
+      }
     },
   },
   methods: {

--- a/src/views/Apply/WorkingPreferences/LocationPreferences.vue
+++ b/src/views/Apply/WorkingPreferences/LocationPreferences.vue
@@ -7,7 +7,7 @@
       <div class="govuk-grid-column-two-thirds">
         <BackLink />
         <h1 class="govuk-heading-xl">
-          Location preferences123
+          Location preferences
         </h1>
 
         <ErrorSummary

--- a/src/views/Apply/WorkingPreferences/workingPreferencesHelper.js
+++ b/src/views/Apply/WorkingPreferences/workingPreferencesHelper.js
@@ -61,10 +61,6 @@ function isAllRequiredFilled(filteredPreferences, formData, formId) {
     const filledPreferenceIds = _.keys(formData[formId]);
     const unfilledRequiredPreferenceIds = _.difference(requiredPreferenceIds, filledPreferenceIds);
     const isAllRequiredFilled = unfilledRequiredPreferenceIds.length === 0;
-    console.log('requiredPreferenceIds', requiredPreferenceIds);
-    console.log('filledPreferenceIds', filledPreferenceIds);
-    console.log('unfilledRequiredPreferences', unfilledRequiredPreferenceIds);
-
     return isAllRequiredFilled;
   } else {
     return formData[formId] ? true : false;

--- a/src/views/Apply/WorkingPreferences/workingPreferencesHelper.js
+++ b/src/views/Apply/WorkingPreferences/workingPreferencesHelper.js
@@ -2,9 +2,12 @@
 
 export {
   filteredPreferences,
+  isAllRequiredFilled,
   tidyData,
   isVersion1
 };
+
+import _ from 'lodash';
 
 function filteredPreferences(vacancy, formData, formId) {
   if (!vacancy) return [];
@@ -51,6 +54,23 @@ function filteredPreferences(vacancy, formData, formId) {
   return mainQuestions.concat(linkedQuestions);
 }
 
+function isAllRequiredFilled(filteredPreferences, formData, formId) {
+  const requiredPreferences = filteredPreferences.filter((p) => p.questionRequired);
+  if (filteredPreferences.length) {
+    const requiredPreferenceIds = _.map(requiredPreferences, 'id');
+    const filledPreferenceIds = _.keys(formData[formId]);
+    const unfilledRequiredPreferenceIds = _.difference(requiredPreferenceIds, filledPreferenceIds);
+    const isAllRequiredFilled = unfilledRequiredPreferenceIds.length === 0;
+    console.log('requiredPreferenceIds', requiredPreferenceIds);
+    console.log('filledPreferenceIds', filledPreferenceIds);
+    console.log('unfilledRequiredPreferences', unfilledRequiredPreferenceIds);
+
+    return isAllRequiredFilled;
+  } else {
+    return formData[formId] ? true : false;
+  }
+}
+
 function tidyData(preferences, data, preference) {
   // check whether we can remove preference that was just updated
   if (preference) {
@@ -86,7 +106,7 @@ function tidyData(preferences, data, preference) {
 function isVersion1(preferences) {
   if (
     preferences
-    && preferences.length 
+    && preferences.length
     && Object.keys(preferences[0]).indexOf('allowLinkedQuestions') < 0
   ) {
     return true;


### PR DESCRIPTION
## What's included?
Closes #1178 
## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
- Apply the vacancy for V2 working preferences: https://jac-apply-develop--pr1206-fix-apply-1178-optio-vzh8kxoo.web.app/vacancy/WazMCe66xTnbKBxcr7b7/
  - Location preferences
     - Leave optional questions empty, it should allow `Save and continue`
  - Jurisdiction Preferences
     - Leave optional questions empty, it should allow `Save and continue`
  - Additional Preferences
     - Leave optional questions empty, it should allow `Save and continue`
- Apply the vacancy for V1 working preferences: https://jac-apply-develop--pr1206-fix-apply-1178-optio-vzh8kxoo.web.app/vacancy/0WqDanorNQnQxHdanxMe/
  - Location preferences
     - All questions are optional
  - Jurisdiction Preferences
     - All questions are mandatory
  - Additional Preferences
     - All questions are mandatory
## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, notes etc.

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
