### PR TITLE
#1212 Single email address on Apply for candidates

### DIFF
--- a/src/components/CandidateProfileLink.vue
+++ b/src/components/CandidateProfileLink.vue
@@ -1,0 +1,16 @@
+<template>
+  <span class="govuk-body-s govuk-!-margin-bottom-0">
+    To edit this field, please visit your <RouterLink
+      class="govuk-link"
+      :to="{ name: 'profile' }"
+    >
+      candidate profile
+    </RouterLink>
+  </span>
+</template>
+
+<script>
+export default {
+  name: 'CandidateProfileLink',
+};
+</script>


### PR DESCRIPTION
## What's included?
Allow **dob and nino** to be editable only once in the Personal Details section of the application. Once **email, dob and nino** have values then display the value with a link to the candidate profile section if they wish to edit them.

Closes #1212 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?

**TEST 1**

1. Login to apply
2. Apply for a vacancy
3. In the Personal Details section the email should be displayed as text with a link next to it to edit it in the candidate profile page
4. In the Personal Details section if the dob is empty then there should be an input which allows you to enter it. Once it's updated it should not be editable in the Personal Details page. It will display as text with a link next to it to edit it in the candidate profile page
5. In the Personal Details section if the NI Number is empty then there should be an input which allows you to enter it. Once it's updated it should not be editable in the Personal Details page. It will display as text with a link next to it to edit it in the candidate profile page

**TEST 2**
- Register a new user on Apply and leave the dob and NI number blank
- Perform the above steps  (2-5)

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context

<img width="840" alt="Screenshot 2024-09-18 at 11 22 00" src="https://github.com/user-attachments/assets/e1114bb5-44c8-4c2c-9f15-923fe0f6e514">

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
