### PR TITLE
Feat/appy 1221 store post qualification experience and relevant qualifications against candidate profile

### DIFF
--- a/src/store/candidate.js
+++ b/src/store/candidate.js
@@ -26,7 +26,7 @@ export default {
       await bindFirestoreRef('personalDetails', doc(collectionRef, `${rootState.auth.currentUser.uid}/documents/personalDetails`), { serialize: vuexfireSerialize });
       await bindFirestoreRef('characterInformation', doc(collectionRef, `${rootState.auth.currentUser.uid}/documents/characterInformation`), { serialize: vuexfireSerialize });
       await bindFirestoreRef('equalityAndDiversitySurvey', doc(collectionRef, `${rootState.auth.currentUser.uid}/documents/equalityAndDiversitySurvey`), { serialize: vuexfireSerialize });
-      await bindFirestoreRef('qualifications', doc(collectionRef, `${rootState.auth.currentUser.uid}/documents/qualifications`), { serialize: vuexfireSerialize });
+      await bindFirestoreRef('relevantQualifications', doc(collectionRef, `${rootState.auth.currentUser.uid}/documents/relevantQualifications`), { serialize: vuexfireSerialize });
       await bindFirestoreRef('postQualificationExperience', doc(collectionRef, `${rootState.auth.currentUser.uid}/documents/postQualificationExperience`), { serialize: vuexfireSerialize });
       return;
     }),
@@ -34,7 +34,7 @@ export default {
       await unbindFirestoreRef('personalDetails');
       await unbindFirestoreRef('characterInformation');
       await unbindFirestoreRef('equalityAndDiversitySurvey');
-      await unbindFirestoreRef('qualifications');
+      await unbindFirestoreRef('relevantQualifications');
       await unbindFirestoreRef('postQualificationExperience');
       return;
     }),
@@ -55,8 +55,8 @@ export default {
       const ref = doc(collectionRef,`${rootState.auth.currentUser.uid}/documents/equalityAndDiversitySurvey`);
       await setDoc(ref, data);
     },
-    saveQualifications: async ({ rootState }, data) => {
-      const ref = doc(collectionRef,`${rootState.auth.currentUser.uid}/documents/qualifications`);
+    saveRelevantQualifications: async ({ rootState }, data) => {
+      const ref = doc(collectionRef,`${rootState.auth.currentUser.uid}/documents/relevantQualifications`);
       await setDoc(ref, data);
     },
     savePostQualificationExperience: async ({ rootState }, data) => {
@@ -73,7 +73,7 @@ export default {
     personalDetails: null,
     characterInformation: null,
     equalityAndDiversitySurvey: null,
-    qualifications: null,
+    relevantQualifications: null,
     postQualificationExperience: null,
   },
   getters: {
@@ -86,8 +86,8 @@ export default {
     equalityAndDiversitySurvey: (state) => () => {
       return clone(state.equalityAndDiversitySurvey);
     },
-    qualifications: (state) => () => {
-      return clone(state.qualifications);
+    relevantQualifications: (state) => () => {
+      return clone(state.relevantQualifications);
     },
     postQualificationExperience: (state) => () => {
       return clone(state.postQualificationExperience);

--- a/src/store/candidate.js
+++ b/src/store/candidate.js
@@ -26,12 +26,16 @@ export default {
       await bindFirestoreRef('personalDetails', doc(collectionRef, `${rootState.auth.currentUser.uid}/documents/personalDetails`), { serialize: vuexfireSerialize });
       await bindFirestoreRef('characterInformation', doc(collectionRef, `${rootState.auth.currentUser.uid}/documents/characterInformation`), { serialize: vuexfireSerialize });
       await bindFirestoreRef('equalityAndDiversitySurvey', doc(collectionRef, `${rootState.auth.currentUser.uid}/documents/equalityAndDiversitySurvey`), { serialize: vuexfireSerialize });
+      await bindFirestoreRef('qualifications', doc(collectionRef, `${rootState.auth.currentUser.uid}/documents/qualifications`), { serialize: vuexfireSerialize });
+      await bindFirestoreRef('postQualificationExperience', doc(collectionRef, `${rootState.auth.currentUser.uid}/documents/postQualificationExperience`), { serialize: vuexfireSerialize });
       return;
     }),
     unbind: firestoreAction(async ({ unbindFirestoreRef }) => {
       await unbindFirestoreRef('personalDetails');
       await unbindFirestoreRef('characterInformation');
       await unbindFirestoreRef('equalityAndDiversitySurvey');
+      await unbindFirestoreRef('qualifications');
+      await unbindFirestoreRef('postQualificationExperience');
       return;
     }),
     create: async ({ rootState, dispatch }, data) => {
@@ -51,6 +55,14 @@ export default {
       const ref = doc(collectionRef,`${rootState.auth.currentUser.uid}/documents/equalityAndDiversitySurvey`);
       await setDoc(ref, data);
     },
+    saveQualifications: async ({ rootState }, data) => {
+      const ref = doc(collectionRef,`${rootState.auth.currentUser.uid}/documents/qualifications`);
+      await setDoc(ref, data);
+    },
+    savePostQualificationExperience: async ({ rootState }, data) => {
+      const ref = doc(collectionRef,`${rootState.auth.currentUser.uid}/documents/postQualificationExperience`);
+      await setDoc(ref, data);
+    },
   },
   mutations: {
     set(state, { name, value }) {
@@ -61,6 +73,8 @@ export default {
     personalDetails: null,
     characterInformation: null,
     equalityAndDiversitySurvey: null,
+    qualifications: null,
+    postQualificationExperience: null,
   },
   getters: {
     personalDetails: (state) => () => {
@@ -71,6 +85,12 @@ export default {
     },
     equalityAndDiversitySurvey: (state) => () => {
       return clone(state.equalityAndDiversitySurvey);
+    },
+    qualifications: (state) => () => {
+      return clone(state.qualifications);
+    },
+    postQualificationExperience: (state) => () => {
+      return clone(state.postQualificationExperience);
     },
   },
 };

--- a/src/views/Apply/QualificationsAndExperience/PostQualificationWorkExperience.vue
+++ b/src/views/Apply/QualificationsAndExperience/PostQualificationWorkExperience.vue
@@ -131,6 +131,16 @@ export default {
     };
     const data = this.$store.getters['application/data'](defaults);
     const formData = { ...defaults, ...data };
+
+    // check if candidate has filled post qualification experience before
+    const candidatePostQualificationExperience = this.$store.getters['candidate/postQualificationExperience']();
+    if (!formData.experience && candidatePostQualificationExperience?.experience) {
+      formData.experience = candidatePostQualificationExperience.experience;
+    }
+    if (!formData.employmentGaps && candidatePostQualificationExperience?.employmentGaps) {
+      formData.employmentGaps = candidatePostQualificationExperience.employmentGaps;
+    }
+
     const experiences = this.sortExperiences(this.getExperiences(formData));
     let editingIndex = null;
     if (experiences.length === 0) {
@@ -209,6 +219,10 @@ export default {
           return res;
         });
       this.$store.dispatch('application/save', this.formData);
+      this.$store.dispatch('candidate/savePostQualificationExperience', {
+        experience: this.formData.experience,
+        employmentGaps: this.formData.employmentGaps,
+      });
     },
     handleRowAdd() {
       this.experiences.push({});

--- a/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
+++ b/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
@@ -180,6 +180,12 @@ export default {
     };
     const data = this.$store.getters['application/data'](defaults);
     const formData = { ...defaults, ...data };
+
+    // check if candidate has filled relevant qualifications before
+    const candidateRelevantQualifications = this.$store.getters['candidate/relevantQualifications']();
+    if (!formData.qualifications && candidateRelevantQualifications?.qualifications) {
+      formData.qualifications = candidateRelevantQualifications?.qualifications;
+    }
     return {
       formId: 'relevantQualifications',
       formData: formData,
@@ -233,6 +239,12 @@ export default {
         }
       }
       this.save();
+      if (this.formData.qualifications) {
+        await this.$store.dispatch('candidate/saveRelevantQualifications', {
+          qualifications: this.formData.qualifications,
+        });
+      }
+
     },
   },
 };


### PR DESCRIPTION
## What's included?
closes #1221 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
- Go to preview link: https://jac-apply-develop--pr1228-feat-appy-1221-store-d1idth6l.web.app/
- Apply one vacancy, then fill and save the `Relevant qualifications` and `Post qualification experience` sections.
<img width="893" alt="Screenshot 2024-09-23 at 15 24 54" src="https://github.com/user-attachments/assets/bbc2aecb-7643-4d42-9523-d3af5dc48f1c">

- Apply another vacancy, check the `Relevant qualifications` and `Post qualification experience` sections, those fields should be filled automatically.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work


## Additional context
Include screen grabs, notes etc.

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
