### PR TITLE
Bugfix/TS 396 Upload Pupillage Exemption Certificate in PDF

### DIFF
--- a/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
+++ b/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
@@ -107,6 +107,7 @@
             v-model="formData.uploadedExemptionCertificate"
             name="exemption-certificate"
             :path="uploadPath"
+            :acceptable-extensions="['docx', 'doc', 'odt', 'txt', 'fodt', 'pdf']"
             label="Exemption certificate"
             required
           />

--- a/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
+++ b/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
@@ -118,6 +118,7 @@
             v-model="formData.uploadedPracticingCertificate"
             name="practicing-certificate"
             :path="uploadPath"
+            :acceptable-extensions="['docx', 'doc', 'odt', 'txt', 'fodt', 'pdf']"
             label="Practicing certificate"
             required
           />
@@ -231,7 +232,7 @@ export default {
   methods: {
     async saveAndValidate() {
       if (this.notCompletedPupillage) {
-        if (this.formData.uploadedExemptionCertificate === null && this.formData.uploadedPracticingCertificate === null) {
+        if (this.formData.uploadedExemptionCertificate === null || this.formData.uploadedPracticingCertificate === null) {
           this.$refs['practicing-certificate'].setError('Please provide a copy of your practicing and/or exemption certificate');
           this.$refs['exemption-certificate'].setError('Please provide a copy of your exemption and/or practicing certificate');
         } else {

--- a/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
+++ b/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
@@ -109,7 +109,7 @@
             :path="uploadPath"
             :acceptable-extensions="['docx', 'doc', 'odt', 'txt', 'fodt', 'pdf']"
             label="Exemption certificate"
-            required
+            :required="isPupillageCertificateRequired"
           />
 
           <FileUpload
@@ -120,7 +120,7 @@
             :path="uploadPath"
             :acceptable-extensions="['docx', 'doc', 'odt', 'txt', 'fodt', 'pdf']"
             label="Practicing certificate"
-            required
+            :required="isPupillageCertificateRequired"
           />
 
           <FormFieldError
@@ -212,6 +212,9 @@ export default {
       }
       return null;
     },
+    isPupillageCertificateRequired() {
+      return this.formData.uploadedExemptionCertificate === null && this.formData.uploadedPracticingCertificate === null;
+    },
   },
   watch: {
     'formData.applyingUnderSchedule2d': function(newVal, oldVal) {
@@ -232,7 +235,7 @@ export default {
   methods: {
     async saveAndValidate() {
       if (this.notCompletedPupillage) {
-        if (this.formData.uploadedExemptionCertificate === null || this.formData.uploadedPracticingCertificate === null) {
+        if (this.formData.uploadedExemptionCertificate === null && this.formData.uploadedPracticingCertificate === null) {
           this.$refs['practicing-certificate'].setError('Please provide a copy of your practicing and/or exemption certificate');
           this.$refs['exemption-certificate'].setError('Please provide a copy of your exemption and/or practicing certificate');
         } else {


### PR DESCRIPTION
## What's included?

[User Raised Issue BR_ADMIN_PR_000191 #396](https://github.com/jac-uk/ticketing-system/issues/396)

- Accept PDF format for the pupillage exemption certificate.

## Who should test?
✅ Product owner
✅ Developers

## How to test?

[Example vacancy on production](https://apply-prod--pr1231-bugfix-ts-396-upload-89pyn137.web.app/vacancy/3Iq5yHs07hrpygGNrGSq/)

1. Apply for the vacancy and go to Relevant qualifications.
2. Check if you can upload an exemption certificate in PDF format.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context

Screenshot:

![image](https://github.com/user-attachments/assets/d4ca2e95-f205-4891-b86f-99a140f5c203)


---
PREVIEW:PRODUCTION
_can be OFF, DEVELOP or STAGING_
