### PR TITLE
Feature/1233 Changes to applications list on Apply

### DIFF
--- a/src/store/vacancies.js
+++ b/src/store/vacancies.js
@@ -75,7 +75,7 @@ export default {
       });
     },
     futureVacancies: (state, getters) => {
-      const vacancies = getters.publishedVacancies;
+      const vacancies = getters.allVacancies;
       return vacancies.filter(vacancy => {
         const openDate = vacancy.applicationOpenDate || parseEstimatedDate(vacancy.estimatedLaunchDate);
         const hasOnlyEstimates = (vacancy.estimatedLaunchDate && (!vacancy.applicationOpenDate && !vacancy.applicationCloseDate));
@@ -89,7 +89,7 @@ export default {
       });
     },
     inProgressVacancies: (state, getters) => {
-      const vacancies = getters.publishedVacancies;
+      const vacancies = getters.allVacancies;
       return vacancies.filter(vacancy => {
         if (!vacancy.applicationCloseDate) {
           return false;

--- a/src/store/vacancies.js
+++ b/src/store/vacancies.js
@@ -51,8 +51,11 @@ export default {
     allVacancies: state => {
       return state.allRecords;
     },
+    publishedVacancies: state => {
+      return state.allRecords.filter(vacancy => vacancy.published);
+    },
     openVacancies: (state, getters) => {
-      const vacancies = getters.allVacancies;
+      const vacancies = getters.publishedVacancies;
       return vacancies.filter(vacancy => {
 
           // console.log(vacancy.state);
@@ -72,7 +75,7 @@ export default {
       });
     },
     futureVacancies: (state, getters) => {
-      const vacancies = getters.allVacancies;
+      const vacancies = getters.publishedVacancies;
       return vacancies.filter(vacancy => {
         const openDate = vacancy.applicationOpenDate || parseEstimatedDate(vacancy.estimatedLaunchDate);
         const hasOnlyEstimates = (vacancy.estimatedLaunchDate && (!vacancy.applicationOpenDate && !vacancy.applicationCloseDate));
@@ -86,7 +89,7 @@ export default {
       });
     },
     inProgressVacancies: (state, getters) => {
-      const vacancies = getters.allVacancies;
+      const vacancies = getters.publishedVacancies;
       return vacancies.filter(vacancy => {
         if (!vacancy.applicationCloseDate) {
           return false;

--- a/src/store/vacancies.js
+++ b/src/store/vacancies.js
@@ -52,15 +52,11 @@ export default {
       return state.allRecords;
     },
     publishedVacancies: state => {
-      return state.allRecords.filter(vacancy => vacancy.published);
+      return state.allRecords.filter(vacancy => vacancy.published && !['deleted', 'archived'].includes(vacancy.state));
     },
     openVacancies: (state, getters) => {
       const vacancies = getters.publishedVacancies;
       return vacancies.filter(vacancy => {
-
-          // console.log(vacancy.state);
-          const isArchived = vacancy.state === 'archived';
-          const isDeleted = vacancy.state === 'deleted';
           const openDate = vacancy.applicationOpenDate || parseEstimatedDate(vacancy.estimatedLaunchDate);
           const closeDate = vacancy.applicationCloseDate || new Date(2050, 1, 1);
           const hasOnlyEstimates = (vacancy.estimatedLaunchDate && (!vacancy.applicationOpenDate && !vacancy.applicationCloseDate));
@@ -71,7 +67,7 @@ export default {
           openDate.setHours(13);
           closeDate.setHours(13);
 
-          return (!isDateInFuture(openDate) && isDateInFuture(closeDate)) && !hasOnlyEstimates && !isArchived && !isDeleted;
+          return (!isDateInFuture(openDate) && isDateInFuture(closeDate)) && !hasOnlyEstimates;
       });
     },
     futureVacancies: (state, getters) => {

--- a/tests/unit/store/vacancies.spec.js
+++ b/tests/unit/store/vacancies.spec.js
@@ -80,7 +80,7 @@ describe('store/vacancies', () => {
     describe('futureVacancies', () => {
       it('returns only future vacancies', () => {
 
-        const futureVacancies = getters.futureVacancies(state, { publishedVacancies: mockVacancies });
+        const futureVacancies = getters.futureVacancies(state, { allVacancies: mockVacancies });
 
         expect(futureVacancies.length).toEqual(1);
         expect(futureVacancies[0].name).toEqual('FUTURE VACANCY');
@@ -93,7 +93,7 @@ describe('store/vacancies', () => {
           estimatedLaunchDate: futureDate,
         };
 
-        const futureVacancies = getters.futureVacancies(state, { publishedVacancies: [mockFutureVacancy, ...mockVacancies] });
+        const futureVacancies = getters.futureVacancies(state, { allVacancies: [mockFutureVacancy, ...mockVacancies] });
 
         expect(futureVacancies.length).toEqual(2);
         expect(futureVacancies[0].name).toEqual(mockName);
@@ -105,7 +105,7 @@ describe('store/vacancies', () => {
           applicationOpenDate: futureDate,
         };
 
-        const futureVacancies = getters.futureVacancies(state, { publishedVacancies: [mockFutureVacancy, ...mockVacancies] });
+        const futureVacancies = getters.futureVacancies(state, { allVacancies: [mockFutureVacancy, ...mockVacancies] });
 
         expect(futureVacancies.length).toEqual(2);
         expect(futureVacancies[0].name).toEqual(mockName);
@@ -115,7 +115,7 @@ describe('store/vacancies', () => {
     describe('inProgressVacancies', () => {
       it('returns only exercises in progress', () => {
 
-        const inProgressVacancies = getters.inProgressVacancies(state, { publishedVacancies: mockVacancies });
+        const inProgressVacancies = getters.inProgressVacancies(state, { allVacancies: mockVacancies });
 
         expect(inProgressVacancies.length).toEqual(1);
         expect(inProgressVacancies[0].name).toEqual('PROGRESS VACANCY');
@@ -128,7 +128,7 @@ describe('store/vacancies', () => {
             applicationOpenDate: pastDate,
         };
 
-        const inProgressVacancies = getters.inProgressVacancies(state, { publishedVacancies: [mockInProgressVacancy, ...mockVacancies] });
+        const inProgressVacancies = getters.inProgressVacancies(state, { allVacancies: [mockInProgressVacancy, ...mockVacancies] });
 
         expect(inProgressVacancies.length).toEqual(1);
         expect(inProgressVacancies[0].name).toEqual('PROGRESS VACANCY');

--- a/tests/unit/store/vacancies.spec.js
+++ b/tests/unit/store/vacancies.spec.js
@@ -44,7 +44,7 @@ describe('store/vacancies', () => {
 
     describe('openVacancies', () => {
       it('returns only open vacancies', () => {
-        const openVacancies = getters.openVacancies(state, { allVacancies: mockVacancies });
+        const openVacancies = getters.openVacancies(state, { publishedVacancies: mockVacancies });
 
         expect(openVacancies.length).toEqual(1);
         expect(openVacancies[0].name).toEqual('OPEN VACANCY');
@@ -58,7 +58,7 @@ describe('store/vacancies', () => {
           applicationCloseDate: futureDate,
         };
 
-        const openVacancies = getters.openVacancies(state, { allVacancies: [mockOpenVacancy, ...mockVacancies] });
+        const openVacancies = getters.openVacancies(state, { publishedVacancies: [mockOpenVacancy, ...mockVacancies] });
 
         expect(openVacancies.length).toEqual(2);
         expect(openVacancies[0].name).toEqual(mockName);
@@ -71,7 +71,7 @@ describe('store/vacancies', () => {
           applicationOpenDate: pastDate,
         };
 
-        const openVacancies = getters.openVacancies(state, { allVacancies: [mockOpenVacancy, ...mockVacancies] });
+        const openVacancies = getters.openVacancies(state, { publishedVacancies: [mockOpenVacancy, ...mockVacancies] });
 
         expect(openVacancies.length).toEqual(2);
         expect(openVacancies[0].name).toEqual(mockName);
@@ -80,7 +80,7 @@ describe('store/vacancies', () => {
     describe('futureVacancies', () => {
       it('returns only future vacancies', () => {
 
-        const futureVacancies = getters.futureVacancies(state, { allVacancies: mockVacancies });
+        const futureVacancies = getters.futureVacancies(state, { publishedVacancies: mockVacancies });
 
         expect(futureVacancies.length).toEqual(1);
         expect(futureVacancies[0].name).toEqual('FUTURE VACANCY');
@@ -93,7 +93,7 @@ describe('store/vacancies', () => {
           estimatedLaunchDate: futureDate,
         };
 
-        const futureVacancies = getters.futureVacancies(state, { allVacancies: [mockFutureVacancy, ...mockVacancies] });
+        const futureVacancies = getters.futureVacancies(state, { publishedVacancies: [mockFutureVacancy, ...mockVacancies] });
 
         expect(futureVacancies.length).toEqual(2);
         expect(futureVacancies[0].name).toEqual(mockName);
@@ -105,7 +105,7 @@ describe('store/vacancies', () => {
           applicationOpenDate: futureDate,
         };
 
-        const futureVacancies = getters.futureVacancies(state, { allVacancies: [mockFutureVacancy, ...mockVacancies] });
+        const futureVacancies = getters.futureVacancies(state, { publishedVacancies: [mockFutureVacancy, ...mockVacancies] });
 
         expect(futureVacancies.length).toEqual(2);
         expect(futureVacancies[0].name).toEqual(mockName);
@@ -115,7 +115,7 @@ describe('store/vacancies', () => {
     describe('inProgressVacancies', () => {
       it('returns only exercises in progress', () => {
 
-        const inProgressVacancies = getters.inProgressVacancies(state, { allVacancies: mockVacancies });
+        const inProgressVacancies = getters.inProgressVacancies(state, { publishedVacancies: mockVacancies });
 
         expect(inProgressVacancies.length).toEqual(1);
         expect(inProgressVacancies[0].name).toEqual('PROGRESS VACANCY');
@@ -128,7 +128,7 @@ describe('store/vacancies', () => {
             applicationOpenDate: pastDate,
         };
 
-        const inProgressVacancies = getters.inProgressVacancies(state, { allVacancies: [mockInProgressVacancy, ...mockVacancies] });
+        const inProgressVacancies = getters.inProgressVacancies(state, { publishedVacancies: [mockInProgressVacancy, ...mockVacancies] });
 
         expect(inProgressVacancies.length).toEqual(1);
         expect(inProgressVacancies[0].name).toEqual('PROGRESS VACANCY');


### PR DESCRIPTION
## What's included?
Closes #1233 

Related PR: [digital-platform: Feature/apply 1233 changes to applications list #1223](https://github.com/jac-uk/digital-platform/pull/1223)

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?

Test user on Apply:
- Email: user2@test.com
- Password: 1qazZAQ!1qaz

1.  Log in to the Apply using the [preview URL](https://jac-apply-develop--pr1236-feature-1233-changes-ct9k22tx.web.app).
2. Check if you view the application of an archived exercise.


## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Demo:

https://github.com/user-attachments/assets/8a47d47c-a5ff-47f5-8a20-ffc3116b33ad

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
