### PR TITLE
Bugfix/1233 Changes to applications list on Apply

### DIFF
--- a/src/store/vacancies.js
+++ b/src/store/vacancies.js
@@ -71,7 +71,7 @@ export default {
       });
     },
     futureVacancies: (state, getters) => {
-      const vacancies = getters.allVacancies;
+      const vacancies = getters.publishedVacancies;
       return vacancies.filter(vacancy => {
         const openDate = vacancy.applicationOpenDate || parseEstimatedDate(vacancy.estimatedLaunchDate);
         const hasOnlyEstimates = (vacancy.estimatedLaunchDate && (!vacancy.applicationOpenDate && !vacancy.applicationCloseDate));
@@ -85,7 +85,7 @@ export default {
       });
     },
     inProgressVacancies: (state, getters) => {
-      const vacancies = getters.allVacancies;
+      const vacancies = getters.publishedVacancies;
       return vacancies.filter(vacancy => {
         if (!vacancy.applicationCloseDate) {
           return false;

--- a/tests/unit/store/vacancies.spec.js
+++ b/tests/unit/store/vacancies.spec.js
@@ -80,7 +80,7 @@ describe('store/vacancies', () => {
     describe('futureVacancies', () => {
       it('returns only future vacancies', () => {
 
-        const futureVacancies = getters.futureVacancies(state, { allVacancies: mockVacancies });
+        const futureVacancies = getters.futureVacancies(state, { publishedVacancies: mockVacancies });
 
         expect(futureVacancies.length).toEqual(1);
         expect(futureVacancies[0].name).toEqual('FUTURE VACANCY');
@@ -93,7 +93,7 @@ describe('store/vacancies', () => {
           estimatedLaunchDate: futureDate,
         };
 
-        const futureVacancies = getters.futureVacancies(state, { allVacancies: [mockFutureVacancy, ...mockVacancies] });
+        const futureVacancies = getters.futureVacancies(state, { publishedVacancies: [mockFutureVacancy, ...mockVacancies] });
 
         expect(futureVacancies.length).toEqual(2);
         expect(futureVacancies[0].name).toEqual(mockName);
@@ -105,7 +105,7 @@ describe('store/vacancies', () => {
           applicationOpenDate: futureDate,
         };
 
-        const futureVacancies = getters.futureVacancies(state, { allVacancies: [mockFutureVacancy, ...mockVacancies] });
+        const futureVacancies = getters.futureVacancies(state, { publishedVacancies: [mockFutureVacancy, ...mockVacancies] });
 
         expect(futureVacancies.length).toEqual(2);
         expect(futureVacancies[0].name).toEqual(mockName);
@@ -115,7 +115,7 @@ describe('store/vacancies', () => {
     describe('inProgressVacancies', () => {
       it('returns only exercises in progress', () => {
 
-        const inProgressVacancies = getters.inProgressVacancies(state, { allVacancies: mockVacancies });
+        const inProgressVacancies = getters.inProgressVacancies(state, { publishedVacancies: mockVacancies });
 
         expect(inProgressVacancies.length).toEqual(1);
         expect(inProgressVacancies[0].name).toEqual('PROGRESS VACANCY');
@@ -128,7 +128,7 @@ describe('store/vacancies', () => {
             applicationOpenDate: pastDate,
         };
 
-        const inProgressVacancies = getters.inProgressVacancies(state, { allVacancies: [mockInProgressVacancy, ...mockVacancies] });
+        const inProgressVacancies = getters.inProgressVacancies(state, { publishedVacancies: [mockInProgressVacancy, ...mockVacancies] });
 
         expect(inProgressVacancies.length).toEqual(1);
         expect(inProgressVacancies[0].name).toEqual('PROGRESS VACANCY');


### PR DESCRIPTION
## What's included?
- Only show published vacancies on Apply.

## Who should test?
✅ Product owner
✅ Developers

## How to test?

[Preview link on production ](https://apply-prod--pr1246-bugfix-1233-changes-zwfz4ivw.web.app/vacancies#closed)

1. Go to the vacancies page.
2. Check if only published vacancies show on the page.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, notes etc.

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
