### PR TITLE
Bugfix/Historic applications not displayed

### DIFF
--- a/src/views/Apply/FinalCheck/Review.vue
+++ b/src/views/Apply/FinalCheck/Review.vue
@@ -1203,6 +1203,7 @@ export default {
       return this.applicationParts.employmentGaps || (this.isApplicationVersionGreaterThan2 && this.applicationParts.postQualificationWorkExperience);
     },
     selfAssessmentSections() {
+      if (!Array.isArray(this.vacancy.selfAssessmentWordLimits)) return [];
       const hasContent = this.vacancy.selfAssessmentWordLimits.some(item => typeof item === 'object' && Object.keys(item).length > 0);
       return hasContent ? this.vacancy.selfAssessmentWordLimits : [];
     },


### PR DESCRIPTION
## What's included?

Related issue: [apply: Changes to applications list on Apply #1233](https://github.com/jac-uk/apply/issues/1233)

The historic applications are not displayed correctly due to some new fields on the review page. 

- Check if the property `vacancy.selfAssessmentWordLimits` is an array before using `some` method.

<img width="791" alt="Screenshot 2024-11-06 at 11 23 08" src="https://github.com/user-attachments/assets/ac60ada9-76e0-45d7-af87-270315e023cb">

## Who should test?
✅ Product owner
✅ Developers

## How to test?

[Preview URL](https://jac-apply-develop--pr1252-bugfix-historic-appl-ibsqthfh.web.app/)

1. Log in via the preview URL.
2. Check if you can access your historic applications without problems. 

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Include screen grabs, notes etc.

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
