### PR TITLE
Bugfix/TS 438 Character information civil proceedings not saved

### DIFF
--- a/src/views/Apply/CharacterInformation/CivilProceedings.vue
+++ b/src/views/Apply/CharacterInformation/CivilProceedings.vue
@@ -30,7 +30,7 @@
                 label="Yes"
               >
                 <RepeatableFields
-                  v-model="characterInformation.furtherInformationDetails"
+                  v-model="characterInformation.civilProceedingsDetails"
                   required
                   :component="repeatableFields.FurtherInformationDetails"
                   :component-props="{
@@ -57,6 +57,7 @@
 </template>
 
 <script>
+import { shallowRef } from 'vue';
 import ErrorSummary from '@/components/Form/ErrorSummary.vue';
 import RadioGroup from '@/components/Form/RadioGroup.vue';
 import RadioItem from '@/components/Form/RadioItem.vue';
@@ -85,9 +86,9 @@ export default {
     return {
       characterInformation: characterInformation,
       formId: 'characterInformation',
-      repeatableFields: {
+      repeatableFields: shallowRef({
         FurtherInformationDetails,
-      },
+      }),
     };
   },
   methods: {

--- a/src/views/Apply/CharacterInformation/FurtherInformation.vue
+++ b/src/views/Apply/CharacterInformation/FurtherInformation.vue
@@ -59,6 +59,7 @@
 </template>
 
 <script>
+import { shallowRef } from 'vue';
 import ErrorSummary from '@/components/Form/ErrorSummary.vue';
 import RadioGroup from '@/components/Form/RadioGroup.vue';
 import RadioItem from '@/components/Form/RadioItem.vue';
@@ -91,9 +92,9 @@ export default {
     return {
       characterInformation: characterInformation,
       formId: 'characterInformation',
-      repeatableFields: {
+      repeatableFields: shallowRef({
         FurtherInformationDetails,
-      },
+      }),
       furtherInformationUrl: FURTHER_INFORMATION_URL,
     };
   },


### PR DESCRIPTION
## What's included?
Related issue: [User Raised Issue BR_ADMIN_PR_000242 #438](https://github.com/jac-uk/ticketing-system/issues/438)

- Fix the stored data on the civil proceedings.
- Fix Vue component warnings.

## Who should test?
✅ Product owner
✅ Developers

## How to test?
[Example vacancy](https://jac-apply-develop--pr1260-bugfix-ts-438-charac-61cs4b3x.web.app/vacancy/gWHwfBAlA9JYqzhwELnx/)

Steps:
1. Apply for the vacancy and go to the Character information section.
2. Check if you can input your record of Civil Proceedings.
3. Check if your data shows correctly on the review page. 

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Demo:

https://github.com/user-attachments/assets/216e416c-b759-4168-a5fc-68fc8d866603

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
