### PR TITLE
1266 Password Reset Not Working

### DIFF
--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -24,16 +24,11 @@ const sendEmailVerificationLink = async () => {
   return false;
 };
 
-const sendPasswordResetLink = async (returnUrl) => {
+const sendPasswordResetLink = async (email, returnUrl) => {
   const auth = getAuth();
-  const user = auth.currentUser;
-  if (user) {
-    await sendPasswordResetEmail(auth, user.email, {
-      url: returnUrl,
-    });
-    return true;
-  }
-  return false;
+  await sendPasswordResetEmail(auth, email, {
+    url: returnUrl,
+  });
 };
 
 export {


### PR DESCRIPTION
## What's included?
Remove the check for a user, which will never exist as the user isnt logged in when they use this functionality. Instead of getting the email from the non-existent user object, get the email from the form field.