### PR TITLE
1253 Include qualification certificates in candidate profile

### DIFF
--- a/src/components/Form/FileUpload.vue
+++ b/src/components/Form/FileUpload.vue
@@ -139,17 +139,8 @@ export default {
     },
   },
   async mounted () {
-
-    console.log('======== FileUpload ========');
-    console.log('-- FU Mounted:');
-    console.log(`-- FU this.path: ${this.path}`);
-    console.log(`-- FU this.fileName: ${this.fileName}`);
-
     if (typeof this.fileName === 'string' && this.fileName.length) {
       const isUploaded = await this.verifyFile(this.fileName);
-
-      console.log(`-- FU isUploaded: ${isUploaded}`);
-
       if (!isUploaded) {
         this.fileName = '';
         this.resetFile();
@@ -200,9 +191,6 @@ export default {
       this.isUploading = false;
     },
     async upload(file) {
-
-      console.log('============= FU Uploading file =============');
-
       // @todo return more useful error messages
       if (!file) {
         this.setError('File upload failed, please try again');
@@ -228,9 +216,6 @@ export default {
       const storage = getStorage();
       const fileRef = ref(storage , uploadedFilePath);
 
-      console.log(`-- FU fileName: ${fileName}`);
-      console.log(`-- FU uploadedFilePath: ${uploadedFilePath}`);
-
       // Delete the current file in file storage
       if (this.haveFile && this.enableDelete) {
         this.deleteFile(this.path, this.modelValue);
@@ -240,11 +225,8 @@ export default {
         await uploadBytes(fileRef, file);
         this.isReplacing = false;
         this.fileName = fileName;
-
         this.downloadUrl = await getDownloadURL(fileRef);
-
-        console.log(`-- FU downloadUrl: ${this.downloadUrl}`);
-
+        // Send the uploadedFilePath back to the parent component
         this.$emit('uploadedFilePath', uploadedFilePath);
 
         return true;
@@ -257,9 +239,6 @@ export default {
       }
     },
     async verifyFile(fileName) {
-
-      console.log('============= FU Verify file =============');
-
       if (!fileName) {
         return false;
       }
@@ -270,9 +249,6 @@ export default {
       // Check if file exists in storage
       try {
         this.downloadUrl = await getDownloadURL(fileRef);
-
-        console.log(`-- FU downloadUrl: ${this.downloadUrl}`);
-
         if (typeof downloadUrl === 'string' && this.downloadUrl.length) {
           return true;
         }

--- a/src/components/Form/FileUpload.vue
+++ b/src/components/Form/FileUpload.vue
@@ -139,8 +139,15 @@ export default {
     },
   },
   async mounted () {
+
+    console.log('======== FileUpload ========');
+    console.log('-- Mounted:');
+    console.log(`-- this.fileName: ${this.fileName}`);
+
     if (typeof this.fileName === 'string' && this.fileName.length) {
       const isUploaded = await this.verifyFile(this.fileName);
+
+      console.log(`-- isUploaded: ${isUploaded}`);
 
       if (!isUploaded) {
         this.fileName = '';
@@ -220,8 +227,8 @@ export default {
       const storage = getStorage();
       const fileRef = ref(storage , uploadedFilePath);
 
-      console.log(`fileName: ${fileName}`);
-      console.log(`store to path/generatedFilename: ${uploadedFilePath}`);
+      console.log(`-- fileName: ${fileName}`);
+      console.log(`-- uploadedFilePath: ${uploadedFilePath}`);
 
       // Delete the current file in file storage
       if (this.haveFile && this.enableDelete) {
@@ -235,7 +242,7 @@ export default {
 
         this.downloadUrl = await getDownloadURL(fileRef);
 
-        console.log(`Donwload url: ${this.downloadUrl}`);
+        console.log(`-- downloadUrl: ${this.downloadUrl}`);
 
         this.$emit('uploadedFilePath', uploadedFilePath);
 
@@ -249,6 +256,9 @@ export default {
       }
     },
     async verifyFile(fileName) {
+
+      console.log('============= Verify file =============');
+
       if (!fileName) {
         return false;
       }
@@ -259,6 +269,8 @@ export default {
       // Check if file exists in storage
       try {
         this.downloadUrl = await getDownloadURL(fileRef);
+
+        console.log(`-- downloadUrl: ${this.downloadUrl}`);
 
         if (typeof downloadUrl === 'string' && this.downloadUrl.length) {
           return true;

--- a/src/components/Form/FileUpload.vue
+++ b/src/components/Form/FileUpload.vue
@@ -141,14 +141,14 @@ export default {
   async mounted () {
 
     console.log('======== FileUpload ========');
-    console.log('-- Mounted:');
-    console.log(`-- this.path: ${this.path}`);
-    console.log(`-- this.fileName: ${this.fileName}`);
+    console.log('-- FU Mounted:');
+    console.log(`-- FU this.path: ${this.path}`);
+    console.log(`-- FU this.fileName: ${this.fileName}`);
 
     if (typeof this.fileName === 'string' && this.fileName.length) {
       const isUploaded = await this.verifyFile(this.fileName);
 
-      console.log(`-- isUploaded: ${isUploaded}`);
+      console.log(`-- FU isUploaded: ${isUploaded}`);
 
       if (!isUploaded) {
         this.fileName = '';
@@ -201,7 +201,7 @@ export default {
     },
     async upload(file) {
 
-      console.log('============= Uploading file =============');
+      console.log('============= FU Uploading file =============');
 
       // @todo return more useful error messages
       if (!file) {
@@ -228,8 +228,8 @@ export default {
       const storage = getStorage();
       const fileRef = ref(storage , uploadedFilePath);
 
-      console.log(`-- fileName: ${fileName}`);
-      console.log(`-- uploadedFilePath: ${uploadedFilePath}`);
+      console.log(`-- FU fileName: ${fileName}`);
+      console.log(`-- FU uploadedFilePath: ${uploadedFilePath}`);
 
       // Delete the current file in file storage
       if (this.haveFile && this.enableDelete) {
@@ -243,7 +243,7 @@ export default {
 
         this.downloadUrl = await getDownloadURL(fileRef);
 
-        console.log(`-- downloadUrl: ${this.downloadUrl}`);
+        console.log(`-- FU downloadUrl: ${this.downloadUrl}`);
 
         this.$emit('uploadedFilePath', uploadedFilePath);
 
@@ -258,7 +258,7 @@ export default {
     },
     async verifyFile(fileName) {
 
-      console.log('============= Verify file =============');
+      console.log('============= FU Verify file =============');
 
       if (!fileName) {
         return false;
@@ -271,7 +271,7 @@ export default {
       try {
         this.downloadUrl = await getDownloadURL(fileRef);
 
-        console.log(`-- downloadUrl: ${this.downloadUrl}`);
+        console.log(`-- FU downloadUrl: ${this.downloadUrl}`);
 
         if (typeof downloadUrl === 'string' && this.downloadUrl.length) {
           return true;

--- a/src/components/Form/FileUpload.vue
+++ b/src/components/Form/FileUpload.vue
@@ -114,7 +114,7 @@ export default {
       },
     },
   },
-  emits: ['update:modelValue', 'uploadedFullPath'],
+  emits: ['update:modelValue', 'uploadedFilePath'],
   data() {
     return {
       file: '',
@@ -216,12 +216,12 @@ export default {
       this.isUploading = true;
       const fileName = this.generateFileName(file.name);
 
-      const uploadedFullPath = `${this.path}/${fileName}`;
+      const uploadedFilePath = `${this.path}/${fileName}`;
       const storage = getStorage();
-      const fileRef = ref(storage , uploadedFullPath);
+      const fileRef = ref(storage , uploadedFilePath);
 
       console.log(`fileName: ${fileName}`);
-      console.log(`store to path/generatedFilename: ${uploadedFullPath}`);
+      console.log(`store to path/generatedFilename: ${uploadedFilePath}`);
 
       // Delete the current file in file storage
       if (this.haveFile && this.enableDelete) {
@@ -237,7 +237,7 @@ export default {
 
         console.log(`Donwload url: ${this.downloadUrl}`);
 
-        this.$emit('uploadedFilePath', uploadedFullPath);
+        this.$emit('uploadedFilePath', uploadedFilePath);
 
         return true;
       } catch (e) {

--- a/src/components/Form/FileUpload.vue
+++ b/src/components/Form/FileUpload.vue
@@ -114,7 +114,7 @@ export default {
       },
     },
   },
-  emits: ['update:modelValue'],
+  emits: ['update:modelValue', 'uploadedFullPath'],
   data() {
     return {
       file: '',
@@ -192,6 +192,9 @@ export default {
       this.isUploading = false;
     },
     async upload(file) {
+
+      console.log('============= Uploading file =============');
+
       // @todo return more useful error messages
       if (!file) {
         this.setError('File upload failed, please try again');
@@ -213,8 +216,12 @@ export default {
       this.isUploading = true;
       const fileName = this.generateFileName(file.name);
 
+      const uploadedFullPath = `${this.path}/${fileName}`;
       const storage = getStorage();
-      const fileRef = ref(storage ,`${this.path}/${fileName}`);
+      const fileRef = ref(storage , uploadedFullPath);
+
+      console.log(`fileName: ${fileName}`);
+      console.log(`store to path/generatedFilename: ${uploadedFullPath}`);
 
       // Delete the current file in file storage
       if (this.haveFile && this.enableDelete) {
@@ -227,6 +234,10 @@ export default {
         this.fileName = fileName;
 
         this.downloadUrl = await getDownloadURL(fileRef);
+
+        console.log(`Donwload url: ${this.downloadUrl}`);
+
+        this.$emit('uploadedFilePath', uploadedFullPath);
 
         return true;
       } catch (e) {

--- a/src/components/Form/FileUpload.vue
+++ b/src/components/Form/FileUpload.vue
@@ -142,6 +142,7 @@ export default {
 
     console.log('======== FileUpload ========');
     console.log('-- Mounted:');
+    console.log(`-- this.path: ${this.path}`);
     console.log(`-- this.fileName: ${this.fileName}`);
 
     if (typeof this.fileName === 'string' && this.fileName.length) {

--- a/src/components/Page/Countdown.vue
+++ b/src/components/Page/Countdown.vue
@@ -15,13 +15,15 @@
       <span
         v-if="status === 'open'"
       >
-        Time left: {{ $filters.zeroPad(minutes) }}:{{ $filters.zeroPad(seconds) }}.
+        Time left: {{ zeroPad(minutes) }}:{{ zeroPad(seconds) }}.
       </span>
     </strong>
   </div>
 </template>
 
 <script>
+import zeroPad from '@/helpers/Form/zeroPad';
+
 const second = 1000;
 const minute = 60 * second;
 
@@ -76,6 +78,7 @@ export default {
     }, second);
   },
   methods: {
+    zeroPad,
     tick(start, end) {
       const now = new Date().getTime();
 

--- a/src/helpers/file.js
+++ b/src/helpers/file.js
@@ -1,0 +1,21 @@
+/**
+ * Split a file path, eg /test1/test2/test3.png returns: ['/test1/test2', 'test3.png']
+ * @param {String} filePath
+ * @returns Array
+ */
+const splitFilePath = async (filePath) => {
+  const splitPath = [];
+  if (filePath) {
+    // Find the last occurrence of the slash
+    const lastSlashIndex = filePath.lastIndexOf('/');
+    // Split the path
+    const directoryPath = filePath.substring(0, lastSlashIndex);
+    const fileName = filePath.substring(lastSlashIndex + 1);
+    splitPath.push(directoryPath, fileName);
+  }
+  return splitPath;
+};
+
+export {
+  splitFilePath
+};

--- a/src/helpers/file.js
+++ b/src/helpers/file.js
@@ -3,7 +3,7 @@
  * @param {String} filePath
  * @returns Array
  */
-const splitFilePath = async (filePath) => {
+const splitFilePath = (filePath) => {
   const splitPath = [];
   if (filePath) {
     // Find the last occurrence of the slash

--- a/src/services/candidateService.js
+++ b/src/services/candidateService.js
@@ -1,6 +1,7 @@
 import store from '@/store';
 import { serverTimestamp } from '@firebase/firestore';
 import { splitFilePath } from '@/helpers/file';
+import _has from 'lodash/has';
 
 const createCandidate = async (personalDetails) => {
   await store.dispatch('candidate/create', {
@@ -33,6 +34,60 @@ const getPracticingCertificateSplitPath = () => {
 
   return latestPracticingCertificateFullPath ? splitFilePath(latestPracticingCertificateFullPath) : [];
 };
+
+const updateRelevantQualifications = async (newCertificateFullPaths, newQualifications = null) {
+  const relevantQualififcations = store.getters['candidate/relevantQualifications']();
+  if (newQualifications) {
+    relevantQualififcations.qualifications = newQualifications;
+  }
+  if (_has(newCertificateFullPaths, 'exemptionCertificateFullPath' && newCertificateFullPaths.exemptionCertificateFullPath)) {
+
+    // Exemption certificate has been added/updated so update the candidate profile
+    console.log('-- RQ exemption certificate has been added/updated so update the candidate profile');
+
+    if (_has(relevantQualififcations, 'uploadedExemptionCertificates')) {
+
+      console.log('-- RQ candidateRelevantQualifications HAS uploadedExemptionCertificates array');
+
+      if (relevantQualififcations.uploadedExemptionCertificates.length > 0) {
+
+        console.log('-- RQ candidateRelevantQualifications.uploadedExemptionCertificates array is not empty so checking last entry');
+
+        const latestEntry = relevantQualififcations.uploadedExemptionCertificates[relevantQualififcations.uploadedExemptionCertificates.length - 1];
+
+        console.log('-- RQ last entry:');
+        console.log(latestEntry);
+
+        if (latestEntry !== newCertificateFullPaths.exemptionCertificateFullPath) {
+
+          console.log('-- RQ last entry IS NOT EQUAL to new one so updating');
+
+          relevantQualififcations.uploadedExemptionCertificates.push(newCertificateFullPaths.exemptionCertificateFullPath);
+        }
+        else {
+          console.log('-- RQ last entry IS EQUAL so NOT updating');
+        }
+      }
+      else {
+
+        console.log('-- RQ candidateRelevantQualifications.uploadedExemptionCertificates array is empty so populate');
+
+        relevantQualififcations.uploadedExemptionCertificates = [newCertificateFullPaths.exemptionCertificateFullPath];
+      }
+    }
+    else {
+
+      console.log('-- RQ candidateRelevantQualifications DOES NOT have uploadedExemptionCertificates array so create it and populate');
+
+      relevantQualififcations.uploadedExemptionCertificates = [newCertificateFullPaths.exemptionCertificateFullPath];
+    }
+
+    await store.dispatch('candidate/saveRelevantQualifications', relevantQualififcations);
+  }
+
+
+
+}
 
 export {
   createCandidate,

--- a/src/services/candidateService.js
+++ b/src/services/candidateService.js
@@ -19,7 +19,7 @@ const makeFullName = (firstName, lastName) => {
 };
 
 const getExemptionCertificateSplitPath = () => {
-  const latestExemptionCertificateFullPath = store.getters['candidate/exemptionCertificateFullPath']();
+  const latestExemptionCertificateFullPath = store.getters['candidate/exemptionCertificateFullPath'];
 
   console.log(`latestExemptionCertificateFullPath: ${latestExemptionCertificateFullPath}`);
 

--- a/src/services/candidateService.js
+++ b/src/services/candidateService.js
@@ -50,7 +50,10 @@ const updateRelevantQualifications = async (newCertificateFullPaths, newQualific
   if (newQualifications) {
     relevantQualififcations.qualifications = newQualifications;
   }
-  if (_has(newCertificateFullPaths, 'exemptionCertificateFullPath' && newCertificateFullPaths.exemptionCertificateFullPath)) {
+
+  // @TODO: ADD THE PRACTICING ONE BELOW TOO!
+
+  if (_has(newCertificateFullPaths, 'exemptionCertificateFullPath') && newCertificateFullPaths.exemptionCertificateFullPath) {
 
     // Exemption certificate has been added/updated so update the candidate profile
     console.log('-- RQ exemption certificate has been added/updated so update the candidate profile');

--- a/src/services/candidateService.js
+++ b/src/services/candidateService.js
@@ -39,7 +39,7 @@ const updateRelevantQualifications = async (newCertificateFullPaths, newQualific
   const relevantQualififcations = store.getters['candidate/relevantQualifications']();
 
   console.log('-- CS candidateRelevantQualifications:');
-  console.log(candidateRelevantQualifications);
+  console.log(relevantQualififcations);
 
   if (newQualifications) {
     relevantQualififcations.qualifications = newQualifications;

--- a/src/services/candidateService.js
+++ b/src/services/candidateService.js
@@ -41,6 +41,12 @@ const updateRelevantQualifications = async (newCertificateFullPaths, newQualific
   console.log('-- CS candidateRelevantQualifications:');
   console.log(relevantQualififcations);
 
+  console.log('-- CS newCertificateFullPaths:');
+  console.log(newCertificateFullPaths);
+
+  console.log('-- CS newQualifications:');
+  console.log(newQualifications);
+
   if (newQualifications) {
     relevantQualififcations.qualifications = newQualifications;
   }

--- a/src/services/candidateService.js
+++ b/src/services/candidateService.js
@@ -37,6 +37,10 @@ const getPracticingCertificateSplitPath = () => {
 
 const updateRelevantQualifications = async (newCertificateFullPaths, newQualifications = null) {
   const relevantQualififcations = store.getters['candidate/relevantQualifications']();
+
+  console.log('-- CS candidateRelevantQualifications:');
+  console.log(candidateRelevantQualifications);
+
   if (newQualifications) {
     relevantQualififcations.qualifications = newQualifications;
   }

--- a/src/services/candidateService.js
+++ b/src/services/candidateService.js
@@ -19,7 +19,7 @@ const makeFullName = (firstName, lastName) => {
 };
 
 const getExemptionCertificateSplitPath = () => {
-  const latestExemptionCertificateFullPath = store.getters['candidate/getExemptionCertificateFullPath']();
+  const latestExemptionCertificateFullPath = store.getters['candidate/exemptionCertificateFullPath']();
 
   console.log(`latestExemptionCertificateFullPath: ${latestExemptionCertificateFullPath}`);
 

--- a/src/services/candidateService.js
+++ b/src/services/candidateService.js
@@ -1,5 +1,6 @@
 import store from '@/store';
 import { serverTimestamp } from '@firebase/firestore';
+import { splitFilePath } from '@/helpers/file';
 
 const createCandidate = async (personalDetails) => {
   await store.dispatch('candidate/create', {
@@ -17,8 +18,17 @@ const makeFullName = (firstName, lastName) => {
   return `${firstName} ${lastName}`;
 };
 
+const getExemptionCertificateSplitPath = () => {
+  const latestExemptionCertificateFullPath = store.getters['candidate/getExemptionCertificateFullPath']();
+
+  console.log(`latestExemptionCertificateFullPath: ${latestExemptionCertificateFullPath}`);
+
+  return latestExemptionCertificateFullPath ? splitFilePath(latestExemptionCertificateFullPath) : [];
+};
+
 export {
   createCandidate,
   saveCandidate,
-  makeFullName
+  makeFullName,
+  getExemptionCertificateSplitPath
 };

--- a/src/services/candidateService.js
+++ b/src/services/candidateService.js
@@ -35,7 +35,7 @@ const getPracticingCertificateSplitPath = () => {
   return latestPracticingCertificateFullPath ? splitFilePath(latestPracticingCertificateFullPath) : [];
 };
 
-const updateRelevantQualifications = async (newCertificateFullPaths, newQualifications = null) {
+const updateRelevantQualifications = async (newCertificateFullPaths, newQualifications = null) => {
   const relevantQualififcations = store.getters['candidate/relevantQualifications']();
 
   console.log('-- CS candidateRelevantQualifications:');
@@ -89,14 +89,13 @@ const updateRelevantQualifications = async (newCertificateFullPaths, newQualific
     await store.dispatch('candidate/saveRelevantQualifications', relevantQualififcations);
   }
 
-
-
-}
+};
 
 export {
   createCandidate,
   saveCandidate,
   makeFullName,
   getExemptionCertificateSplitPath,
-  getPracticingCertificateSplitPath
+  getPracticingCertificateSplitPath,
+  updateRelevantQualifications
 };

--- a/src/services/candidateService.js
+++ b/src/services/candidateService.js
@@ -21,7 +21,7 @@ const makeFullName = (firstName, lastName) => {
 const getExemptionCertificateSplitPath = () => {
   const latestExemptionCertificateFullPath = store.getters['candidate/exemptionCertificateFullPath'];
 
-  console.log(`latestExemptionCertificateFullPath: ${latestExemptionCertificateFullPath}`);
+  console.log(`CS latestExemptionCertificateFullPath: ${latestExemptionCertificateFullPath}`);
 
   return latestExemptionCertificateFullPath ? splitFilePath(latestExemptionCertificateFullPath) : [];
 };
@@ -29,7 +29,7 @@ const getExemptionCertificateSplitPath = () => {
 const getPracticingCertificateSplitPath = () => {
   const latestPracticingCertificateFullPath = store.getters['candidate/practicingCertificateFullPath'];
 
-  console.log(`latestPracticingCertificateFullPath: ${latestPracticingCertificateFullPath}`);
+  console.log(`CS latestPracticingCertificateFullPath: ${latestPracticingCertificateFullPath}`);
 
   return latestPracticingCertificateFullPath ? splitFilePath(latestPracticingCertificateFullPath) : [];
 };

--- a/src/services/candidateService.js
+++ b/src/services/candidateService.js
@@ -51,8 +51,7 @@ const updateRelevantQualifications = async (newCertificateFullPaths, newQualific
     relevantQualififcations.qualifications = newQualifications;
   }
 
-  // @TODO: ADD THE PRACTICING ONE BELOW TOO!
-
+  // EXEMPTION CERTIFICATE
   if (_has(newCertificateFullPaths, 'exemptionCertificateFullPath') && newCertificateFullPaths.exemptionCertificateFullPath) {
 
     // Exemption certificate has been added/updated so update the candidate profile
@@ -94,9 +93,53 @@ const updateRelevantQualifications = async (newCertificateFullPaths, newQualific
 
       relevantQualififcations.uploadedExemptionCertificates = [newCertificateFullPaths.exemptionCertificateFullPath];
     }
-
-    await store.dispatch('candidate/saveRelevantQualifications', relevantQualififcations);
   }
+
+  // PRACTICING CERTIFICATE
+  if (_has(newCertificateFullPaths, 'practicingCertificateFullPath') && newCertificateFullPaths.practicingCertificateFullPath) {
+
+    // Practicing certificate has been added/updated so update the candidate profile
+    console.log('-- RQ practicing certificate has been added/updated so update the candidate profile');
+
+    if (_has(relevantQualififcations, 'uploadedPracticingCertificates')) {
+
+      console.log('-- RQ candidateRelevantQualifications HAS uploadedPracticingCertificates array');
+
+      if (relevantQualififcations.uploadedPracticingCertificates.length > 0) {
+
+        console.log('-- RQ candidateRelevantQualifications.uploadedPracticingCertificates array is not empty so checking last entry');
+
+        const latestEntry = relevantQualififcations.uploadedPracticingCertificates[relevantQualififcations.uploadedPracticingCertificates.length - 1];
+
+        console.log('-- RQ last entry:');
+        console.log(latestEntry);
+
+        if (latestEntry !== newCertificateFullPaths.practicingCertificateFullPath) {
+
+          console.log('-- RQ last entry IS NOT EQUAL to new one so updating');
+
+          relevantQualififcations.uploadedPracticingCertificates.push(newCertificateFullPaths.practicingCertificateFullPath);
+        }
+        else {
+          console.log('-- RQ last entry IS EQUAL so NOT updating');
+        }
+      }
+      else {
+
+        console.log('-- RQ candidateRelevantQualifications.uploadedPracticingCertificates array is empty so populate');
+
+        relevantQualififcations.uploadedPracticingCertificates = [newCertificateFullPaths.practicingCertificateFullPath];
+      }
+    }
+    else {
+
+      console.log('-- RQ candidateRelevantQualifications DOES NOT have uploadedPracticingCertificates array so create it and populate');
+
+      relevantQualififcations.uploadedPracticingCertificates = [newCertificateFullPaths.practicingCertificateFullPath];
+    }
+  }
+
+  await store.dispatch('candidate/saveRelevantQualifications', relevantQualififcations);
 
 };
 

--- a/src/services/candidateService.js
+++ b/src/services/candidateService.js
@@ -26,9 +26,18 @@ const getExemptionCertificateSplitPath = () => {
   return latestExemptionCertificateFullPath ? splitFilePath(latestExemptionCertificateFullPath) : [];
 };
 
+const getPracticingCertificateSplitPath = () => {
+  const latestPracticingCertificateFullPath = store.getters['candidate/practicingCertificateFullPath'];
+
+  console.log(`latestPracticingCertificateFullPath: ${latestPracticingCertificateFullPath}`);
+
+  return latestPracticingCertificateFullPath ? splitFilePath(latestPracticingCertificateFullPath) : [];
+};
+
 export {
   createCandidate,
   saveCandidate,
   makeFullName,
-  getExemptionCertificateSplitPath
+  getExemptionCertificateSplitPath,
+  getPracticingCertificateSplitPath
 };

--- a/src/services/candidateService.js
+++ b/src/services/candidateService.js
@@ -19,128 +19,73 @@ const makeFullName = (firstName, lastName) => {
   return `${firstName} ${lastName}`;
 };
 
+/**
+ * Split the filepath to return an array of [path, filename]
+ * @returns Array
+ */
 const getExemptionCertificateSplitPath = () => {
   const latestExemptionCertificateFullPath = store.getters['candidate/exemptionCertificateFullPath'];
-
-  console.log(`CS latestExemptionCertificateFullPath: ${latestExemptionCertificateFullPath}`);
-
   return latestExemptionCertificateFullPath ? splitFilePath(latestExemptionCertificateFullPath) : [];
 };
 
+/**
+ * Split the filepath to return an array of [path, filename]
+ * @returns Array
+ */
 const getPracticingCertificateSplitPath = () => {
   const latestPracticingCertificateFullPath = store.getters['candidate/practicingCertificateFullPath'];
-
-  console.log(`CS latestPracticingCertificateFullPath: ${latestPracticingCertificateFullPath}`);
-
   return latestPracticingCertificateFullPath ? splitFilePath(latestPracticingCertificateFullPath) : [];
 };
 
+/**
+ * Update the releavant qualifications
+ * The certificates are stored in arrays where the latest entry is the current certificate
+ * New uploaded files have their filepath appended to the array
+ * @param {Object} newCertificateFullPaths
+ * @param {Array} newQualifications
+ */
 const updateRelevantQualifications = async (newCertificateFullPaths, newQualifications = null) => {
   const relevantQualififcations = store.getters['candidate/relevantQualifications']();
-
-  console.log('-- CS candidateRelevantQualifications:');
-  console.log(relevantQualififcations);
-
-  console.log('-- CS newCertificateFullPaths:');
-  console.log(newCertificateFullPaths);
-
-  console.log('-- CS newQualifications:');
-  console.log(newQualifications);
-
   if (newQualifications) {
     relevantQualififcations.qualifications = newQualifications;
   }
-
-  // EXEMPTION CERTIFICATE
+  // Exemption Certificate
   if (_has(newCertificateFullPaths, 'exemptionCertificateFullPath') && newCertificateFullPaths.exemptionCertificateFullPath) {
-
     // Exemption certificate has been added/updated so update the candidate profile
-    console.log('-- RQ exemption certificate has been added/updated so update the candidate profile');
-
     if (_has(relevantQualififcations, 'uploadedExemptionCertificates')) {
-
-      console.log('-- RQ candidateRelevantQualifications HAS uploadedExemptionCertificates array');
-
       if (relevantQualififcations.uploadedExemptionCertificates.length > 0) {
-
-        console.log('-- RQ candidateRelevantQualifications.uploadedExemptionCertificates array is not empty so checking last entry');
-
         const latestEntry = relevantQualififcations.uploadedExemptionCertificates[relevantQualififcations.uploadedExemptionCertificates.length - 1];
-
-        console.log('-- RQ last entry:');
-        console.log(latestEntry);
-
         if (latestEntry !== newCertificateFullPaths.exemptionCertificateFullPath) {
-
-          console.log('-- RQ last entry IS NOT EQUAL to new one so updating');
-
           relevantQualififcations.uploadedExemptionCertificates.push(newCertificateFullPaths.exemptionCertificateFullPath);
-        }
-        else {
-          console.log('-- RQ last entry IS EQUAL so NOT updating');
         }
       }
       else {
-
-        console.log('-- RQ candidateRelevantQualifications.uploadedExemptionCertificates array is empty so populate');
-
         relevantQualififcations.uploadedExemptionCertificates = [newCertificateFullPaths.exemptionCertificateFullPath];
       }
     }
     else {
-
-      console.log('-- RQ candidateRelevantQualifications DOES NOT have uploadedExemptionCertificates array so create it and populate');
-
       relevantQualififcations.uploadedExemptionCertificates = [newCertificateFullPaths.exemptionCertificateFullPath];
     }
   }
-
-  // PRACTICING CERTIFICATE
+  // Practicing Certificate
   if (_has(newCertificateFullPaths, 'practicingCertificateFullPath') && newCertificateFullPaths.practicingCertificateFullPath) {
-
     // Practicing certificate has been added/updated so update the candidate profile
-    console.log('-- RQ practicing certificate has been added/updated so update the candidate profile');
-
     if (_has(relevantQualififcations, 'uploadedPracticingCertificates')) {
-
-      console.log('-- RQ candidateRelevantQualifications HAS uploadedPracticingCertificates array');
-
       if (relevantQualififcations.uploadedPracticingCertificates.length > 0) {
-
-        console.log('-- RQ candidateRelevantQualifications.uploadedPracticingCertificates array is not empty so checking last entry');
-
         const latestEntry = relevantQualififcations.uploadedPracticingCertificates[relevantQualififcations.uploadedPracticingCertificates.length - 1];
-
-        console.log('-- RQ last entry:');
-        console.log(latestEntry);
-
         if (latestEntry !== newCertificateFullPaths.practicingCertificateFullPath) {
-
-          console.log('-- RQ last entry IS NOT EQUAL to new one so updating');
-
           relevantQualififcations.uploadedPracticingCertificates.push(newCertificateFullPaths.practicingCertificateFullPath);
-        }
-        else {
-          console.log('-- RQ last entry IS EQUAL so NOT updating');
         }
       }
       else {
-
-        console.log('-- RQ candidateRelevantQualifications.uploadedPracticingCertificates array is empty so populate');
-
         relevantQualififcations.uploadedPracticingCertificates = [newCertificateFullPaths.practicingCertificateFullPath];
       }
     }
     else {
-
-      console.log('-- RQ candidateRelevantQualifications DOES NOT have uploadedPracticingCertificates array so create it and populate');
-
       relevantQualififcations.uploadedPracticingCertificates = [newCertificateFullPaths.practicingCertificateFullPath];
     }
   }
-
   await store.dispatch('candidate/saveRelevantQualifications', relevantQualififcations);
-
 };
 
 export {

--- a/src/store/candidate.js
+++ b/src/store/candidate.js
@@ -113,19 +113,21 @@ export default {
     requiredFieldsComplete: (state) => () => {
       return clone(state.requiredFieldsComplete);
     },
-    exemptionCertificateFullPath: (state) => {
+    exemptionCertificateFullPath: (getters) => {
       // Get the lastest exemption certificate (full path) in the list, if it exists
-      if (state.relevantQualifications === null) return null;
-      if (_has(state.relevantQualifications, 'uploadedExemptionCertificates') && Array.isArray(state.relevantQualifications.uploadedExemptionCertificates) && state.relevantQualifications.uploadedExemptionCertificates.length > 0) {
-        return state.relevantQualifications.uploadedExemptionCertificates[state.relevantQualifications.uploadedExemptionCertificates.length - 1];
+      const relevantQualifications = getters.relevantQualifications();
+      if (relevantQualifications === null) return null;
+      if (_has(relevantQualifications, 'uploadedExemptionCertificates') && Array.isArray(relevantQualifications.uploadedExemptionCertificates) && relevantQualifications.uploadedExemptionCertificates.length > 0) {
+        return relevantQualifications.uploadedExemptionCertificates[relevantQualifications.uploadedExemptionCertificates.length - 1];
       }
       return null;
     },
-    practicingCertificateFullPath: (state) => {
+    practicingCertificateFullPath: (getters) => {
       // Get the lastest practicing certificate (full path) in the list, if it exists
-      if (state.relevantQualifications === null) return null;
-      if (_has(state.relevantQualifications, 'uploadedPracticingCertificates') && Array.isArray(state.relevantQualifications.uploadedPracticingCertificates) && state.relevantQualifications.uploadedPracticingCertificates.length > 0) {
-        return state.relevantQualifications.uploadedPracticingCertificates[state.relevantQualifications.uploadedPracticingCertificates.length - 1];
+      const relevantQualifications = getters.relevantQualifications();
+      if (relevantQualifications === null) return null;
+      if (_has(relevantQualifications, 'uploadedPracticingCertificates') && Array.isArray(relevantQualifications.uploadedPracticingCertificates) && relevantQualifications.uploadedPracticingCertificates.length > 0) {
+        return relevantQualifications.uploadedPracticingCertificates[relevantQualifications.uploadedPracticingCertificates.length - 1];
       }
       return null;
     },

--- a/src/store/candidate.js
+++ b/src/store/candidate.js
@@ -115,7 +115,7 @@ export default {
     },
     exemptionCertificateFullPath: (getters) => {
       // Get the lastest exemption certificate (full path) in the list, if it exists
-      const relevantQualifications = getters.relevantQualifications();
+      const relevantQualifications = getters.relevantQualifications;
       if (relevantQualifications === null) return null;
       if (_has(relevantQualifications, 'uploadedExemptionCertificates') && Array.isArray(relevantQualifications.uploadedExemptionCertificates) && relevantQualifications.uploadedExemptionCertificates.length > 0) {
         return relevantQualifications.uploadedExemptionCertificates[relevantQualifications.uploadedExemptionCertificates.length - 1];
@@ -124,7 +124,7 @@ export default {
     },
     practicingCertificateFullPath: (getters) => {
       // Get the lastest practicing certificate (full path) in the list, if it exists
-      const relevantQualifications = getters.relevantQualifications();
+      const relevantQualifications = getters.relevantQualifications;
       if (relevantQualifications === null) return null;
       if (_has(relevantQualifications, 'uploadedPracticingCertificates') && Array.isArray(relevantQualifications.uploadedPracticingCertificates) && relevantQualifications.uploadedPracticingCertificates.length > 0) {
         return relevantQualifications.uploadedPracticingCertificates[relevantQualifications.uploadedPracticingCertificates.length - 1];

--- a/src/store/candidate.js
+++ b/src/store/candidate.js
@@ -3,6 +3,7 @@ import { firestore } from '@/firebase';
 import { firestoreAction } from '@/helpers/vuexfireJAC';
 import vuexfireSerialize from '@/helpers/vuexfireSerialize';
 import clone from 'clone';
+import _has from 'lodash/has';
 
 const collectionName = 'candidates';
 const collectionRef = collection(firestore, collectionName);
@@ -111,6 +112,22 @@ export default {
     },
     requiredFieldsComplete: (state) => () => {
       return clone(state.requiredFieldsComplete);
+    },
+    exemptionCertificateFullPath: (state) => {
+      // Get the lastest exemption certificate (full path) in the list, if it exists
+      if (state.relevantQualifications === null) return null;
+      if (_has(state.relevantQualifications, 'uploadedExemptionCertificates') && Array.isArray(state.relevantQualifications.uploadedExemptionCertificates) && state.relevantQualifications.uploadedExemptionCertificates.length > 0) {
+        return state.relevantQualifications.uploadedExemptionCertificates[state.relevantQualifications.uploadedExemptionCertificates.length - 1];
+      }
+      return null;
+    },
+    practicingCertificateFullPath: (state) => {
+      // Get the lastest practicing certificate (full path) in the list, if it exists
+      if (state.relevantQualifications === null) return null;
+      if (_has(state.relevantQualifications, 'uploadedPracticingCertificates') && Array.isArray(state.relevantQualifications.uploadedPracticingCertificates) && state.relevantQualifications.uploadedPracticingCertificates.length > 0) {
+        return state.relevantQualifications.uploadedPracticingCertificates[state.relevantQualifications.uploadedPracticingCertificates.length - 1];
+      }
+      return null;
     },
   },
 };

--- a/src/views/Apply/ApplyMixIn.js
+++ b/src/views/Apply/ApplyMixIn.js
@@ -180,10 +180,6 @@ export default {
       this.validate();
       if (this.isValid() && this.formId) {
         this.formData.progress[this.formId] = true;
-
-        console.log('Saving the formData to the application:');
-        console.log(this.formData);
-
         await this.$store.dispatch('application/save', this.formData);
         this.logEventAfterSave();
         this.$router.push({ name: 'task-list' });

--- a/src/views/Apply/ApplyMixIn.js
+++ b/src/views/Apply/ApplyMixIn.js
@@ -180,6 +180,10 @@ export default {
       this.validate();
       if (this.isValid() && this.formId) {
         this.formData.progress[this.formId] = true;
+
+        console.log('Saving the formData to the application:');
+        console.log(this.formData);
+
         await this.$store.dispatch('application/save', this.formData);
         this.logEventAfterSave();
         this.$router.push({ name: 'task-list' });

--- a/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
+++ b/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
@@ -101,30 +101,6 @@
         <template v-if="notCompletedPupillage">
           <h2>As you did not complete pupillage, please provide a copy of your exemption and or practicing certificate</h2>
 
-          <!-- <FileUpload
-            id="exemption-certificate-upload"
-            ref="exemption-certificate"
-            v-model="formData.uploadedExemptionCertificate"
-            name="exemption-certificate"
-            :path="uploadPath"
-            :acceptable-extensions="['docx', 'doc', 'odt', 'txt', 'fodt', 'pdf']"
-            label="Exemption certificate"
-            :required="isPupillageCertificateRequired"
-            @uploaded-file-path="setExemptionCertificateFullPath"
-          />
-
-          <FileUpload
-            id="practicing-certificate-upload"
-            ref="practicing-certificate"
-            v-model="formData.uploadedPracticingCertificate"
-            name="practicing-certificate"
-            :path="uploadPath"
-            :acceptable-extensions="['docx', 'doc', 'odt', 'txt', 'fodt', 'pdf']"
-            label="Practicing certificate"
-            :required="isPupillageCertificateRequired"
-            @uploaded-file-path="setPracticingCertificateFullPath"
-          /> -->
-
           <FileUpload
             id="exemption-certificate-upload"
             ref="exemption-certificate"
@@ -208,110 +184,7 @@ export default {
       progress: {},
     };
     const data = this.$store.getters['application/data'](defaults);
-
-    console.log('============ RELEVANT QUALIFICATION ===============');
-
-    // - when testing switch between .docx and .doc files!
-
-    console.log('-- RQ Application data:');
-    console.log(data);
-
     const formData = { ...defaults, ...data };
-
-    console.log('-- RQ Initial formData:');
-    console.log(formData);
-
-    // // check if candidate has filled relevant qualifications before
-    // const candidateRelevantQualifications = this.$store.getters['candidate/relevantQualifications']();
-
-    // console.log('-- RQ candidateRelevantQualifications:');
-    // console.log(candidateRelevantQualifications);
-
-    // if (!formData.qualifications && candidateRelevantQualifications?.qualifications) {
-    //   formData.qualifications = candidateRelevantQualifications?.qualifications;
-    // }
-
-    // // @TODO: Certificates
-    // const exemptionCertificateSplitPath = getExemptionCertificateSplitPath();
-    // console.log('-- RQ exemptionCertificateSplitPath:');
-    // console.log(exemptionCertificateSplitPath);
-    // if (exemptionCertificateSplitPath.length > 0) {
-    //   // eg /exercise/gWHwfBAlA9JYqzhwELnx/user/UhG4MVCdVpbSZAyZHOgB2LIidFj
-    //   console.log(`-- RQ exemptionCertificateSplitPath[0]: ${exemptionCertificateSplitPath[0]}`);
-
-    //   // eg exemption-certificate.docx
-    //   console.log(`-- RQ exemptionCertificateSplitPath[1]: ${exemptionCertificateSplitPath[1]}`);
-    // }
-
-    // const practicingCertificateSplitPath = getPracticingCertificateSplitPath();
-    // console.log('-- RQ practicingCertificateSplitPath:');
-    // console.log(practicingCertificateSplitPath);
-    // if (practicingCertificateSplitPath.length > 0) {
-    //   // eg /exercise/gWHwfBAlA9JYqzhwELnx/user/UhG4MVCdVpbSZAyZHOgB2LIidFj
-    //   console.log(`-- RQ practicingCertificateSplitPath[0]: ${practicingCertificateSplitPath[0]}`);
-
-    //   // eg practicing-certificate.docx
-    //   console.log(`-- RQ practicingCertificateSplitPath[1]: ${practicingCertificateSplitPath[1]}`);
-    // }
-
-    // // Check if the application has the uploadedExemptionCertificate set and, if so, use it
-    // //    Set the path for the FileUpload component (and formData.uploadedPracticingCertificate is already set!)
-    // //    => const fileUploadPath = this.uploadPath;
-    // // Else if its in the candidate record
-    // //    formData.uploadedPracticingCertificate = exemptionCertificateSplitPath[1]
-    // //    fileUploadPath = exemptionCertificateSplitPath[0]
-
-    // let exemptionCertFileUploadPath = this.uploadPath;
-    // let practicingCertFileUploadPath = this.uploadPath;
-
-    // console.log(`-- RQ THIS.UPLOADPATH: ${this.uploadPath}`);
-
-    // // console.log(`-- formData['uploadedExemptionCertificate']: ${formData['uploadedExemptionCertificate']}`);
-    // // console.log(`-- exemptionCertificateSplitPath.length']: ${exemptionCertificateSplitPath.length}`);
-
-    // // EXEMPTION CERTIFICATE
-    // if (_has(formData, 'uploadedExemptionCertificate') && formData.uploadedExemptionCertificate) {
-    //   console.log('-- RQ Getting exemption certificate from the APPLICATION');
-    //   console.log(`-- RQ exemptionCertFileUploadPath: ${exemptionCertFileUploadPath}`);
-    // }
-    // else if ((!_has(formData, 'uploadedExemptionCertificate') || !formData.uploadedExemptionCertificate) && exemptionCertificateSplitPath.length === 2) {
-    //   console.log('-- RQ Getting exemption certificate from the CANDIDATE PROFILE');
-
-    //   // @TODO: COMMENTED OUT BELOW TO SHOW WHAT THE DATA LOOKS LIKE, NOW NEED TO TEST IT WHEN THIS IS UNCOMMENTED AND ENSURE THE FILE STILL SHOWS IN FILE UPLOAD!!
-
-    //   formData.uploadedExemptionCertificate = exemptionCertificateSplitPath[1];
-    //   exemptionCertFileUploadPath = exemptionCertificateSplitPath[0];
-    // }
-    // else {
-    //   console.log('-- RQ NOT getting exemption certificate from ANYWHERE');
-    // }
-
-    // // PRACTICING CERTIFICATE
-    // if (_has(formData, 'uploadedPracticingCertificate') && formData.uploadedPracticingCertificate) {
-    //   console.log('-- RQ Getting practicing certificate from the APPLICATION');
-    // }
-    // else if ((!_has(formData, 'uploadedPracticingCertificate') || !formData.uploadedPracticingCertificate) && practicingCertificateSplitPath.length === 2) {
-    //   console.log('-- RQ Getting practicing certificate from the CANDIDATE PROFILE');
-
-    //   // @TODO: COMMENTED OUT BELOW TO SHOW WHAT THE DATA LOOKS LIKE, NOW NEED TO TEST IT WHEN THIS IS UNCOMMENTED AND ENSURE THE FILE STILL SHOWS IN FILE UPLOAD!!
-
-    //   formData.uploadedPracticingCertificate = practicingCertificateSplitPath[1];
-    //   practicingCertFileUploadPath = practicingCertificateSplitPath[0];
-    // }
-    // else {
-    //   console.log('-- RQ NOT getting practicing certificate from ANYWHERE');
-    // }
-
-    // // @TODO: see above, its returning a promise instead of the value!!
-
-    // // Path to FileUpload component: /exercise/gWHwfBAlA9JYqzhwELnx/user/UhG4MVCdVpbSZAyZHOgB2LIidFj2
-    // // Filename to FileUpload component: exemption-certificate.docx
-
-    // console.log('-- RQ Eventual formData:');
-    // console.log(formData);
-
-    // // @TODO: Similar to above check for existing files in candidate record and load it if nowt in the formData (ie the application)!
-
     return {
       formId: 'relevantQualifications',
       formData: formData,
@@ -364,113 +237,36 @@ export default {
     },
   },
   created() {
-    // const data = this.$store.getters['application/data'](this.defaults);
-
-    // console.log('============ RELEVANT QUALIFICATION ===============');
-
-    // // - when testing switch between .docx and .doc files!
-
-    // console.log('-- RQ Application data:');
-    // console.log(data);
-
-    // //this.formData = { ...this.defaults, ...data };
-
-    // console.log('-- RQ Initial formData:');
-    // console.log(this.formData);
-
-    // check if candidate has filled relevant qualifications before
-    const candidateRelevantQualifications = this.$store.getters['candidate/relevantQualifications']();
-
-    console.log('-- RQ candidateRelevantQualifications:');
-    console.log(candidateRelevantQualifications);
-
-    if (!this.formData.qualifications && candidateRelevantQualifications?.qualifications) {
-      this.formData.qualifications = candidateRelevantQualifications?.qualifications;
-    }
-
-    // @TODO: Certificates
-    const exemptionCertificateSplitPath = getExemptionCertificateSplitPath();
-    console.log('-- RQ exemptionCertificateSplitPath:');
-    console.log(exemptionCertificateSplitPath);
-    if (exemptionCertificateSplitPath.length > 0) {
-      // eg /exercise/gWHwfBAlA9JYqzhwELnx/user/UhG4MVCdVpbSZAyZHOgB2LIidFj
-      console.log(`-- RQ exemptionCertificateSplitPath[0]: ${exemptionCertificateSplitPath[0]}`);
-
-      // eg exemption-certificate.docx
-      console.log(`-- RQ exemptionCertificateSplitPath[1]: ${exemptionCertificateSplitPath[1]}`);
-    }
-
-    const practicingCertificateSplitPath = getPracticingCertificateSplitPath();
-    console.log('-- RQ practicingCertificateSplitPath:');
-    console.log(practicingCertificateSplitPath);
-    if (practicingCertificateSplitPath.length > 0) {
-      // eg /exercise/gWHwfBAlA9JYqzhwELnx/user/UhG4MVCdVpbSZAyZHOgB2LIidFj
-      console.log(`-- RQ practicingCertificateSplitPath[0]: ${practicingCertificateSplitPath[0]}`);
-
-      // eg practicing-certificate.docx
-      console.log(`-- RQ practicingCertificateSplitPath[1]: ${practicingCertificateSplitPath[1]}`);
-    }
-
-    // Check if the application has the uploadedExemptionCertificate set and, if so, use it
-    //    Set the path for the FileUpload component (and formData.uploadedPracticingCertificate is already set!)
-    //    => const fileUploadPath = this.uploadPath;
-    // Else if its in the candidate record
-    //    formData.uploadedPracticingCertificate = exemptionCertificateSplitPath[1]
-    //    fileUploadPath = exemptionCertificateSplitPath[0]
-
-    this.exemptionCertFileUploadPath = this.uploadPath;
-    this.practicingCertFileUploadPath = this.uploadPath;
-
-    console.log(`-- RQ THIS.UPLOADPATH: ${this.uploadPath}`);
-
-    // console.log(`-- formData['uploadedExemptionCertificate']: ${formData['uploadedExemptionCertificate']}`);
-    // console.log(`-- exemptionCertificateSplitPath.length']: ${exemptionCertificateSplitPath.length}`);
-
-    // EXEMPTION CERTIFICATE
-    if (_has(this.formData, 'uploadedExemptionCertificate') && this.formData.uploadedExemptionCertificate) {
-      console.log('-- RQ Getting exemption certificate from the APPLICATION');
-      console.log(`-- RQ exemptionCertFileUploadPath: ${this.exemptionCertFileUploadPath}`);
-    }
-    else if ((!_has(this.formData, 'uploadedExemptionCertificate') || !this.formData.uploadedExemptionCertificate) && exemptionCertificateSplitPath.length === 2) {
-      console.log('-- RQ Getting exemption certificate from the CANDIDATE PROFILE');
-
-      // @TODO: COMMENTED OUT BELOW TO SHOW WHAT THE DATA LOOKS LIKE, NOW NEED TO TEST IT WHEN THIS IS UNCOMMENTED AND ENSURE THE FILE STILL SHOWS IN FILE UPLOAD!!
-
-      this.formData.uploadedExemptionCertificate = exemptionCertificateSplitPath[1];
-      this.exemptionCertFileUploadPath = exemptionCertificateSplitPath[0];
-    }
-    else {
-      console.log('-- RQ NOT getting exemption certificate from ANYWHERE');
-    }
-
-    // PRACTICING CERTIFICATE
-    if (_has(this.formData, 'uploadedPracticingCertificate') && this.formData.uploadedPracticingCertificate) {
-      console.log('-- RQ Getting practicing certificate from the APPLICATION');
-    }
-    else if ((!_has(this.formData, 'uploadedPracticingCertificate') || !this.formData.uploadedPracticingCertificate) && practicingCertificateSplitPath.length === 2) {
-      console.log('-- RQ Getting practicing certificate from the CANDIDATE PROFILE');
-
-      // @TODO: COMMENTED OUT BELOW TO SHOW WHAT THE DATA LOOKS LIKE, NOW NEED TO TEST IT WHEN THIS IS UNCOMMENTED AND ENSURE THE FILE STILL SHOWS IN FILE UPLOAD!!
-
-      this.formData.uploadedPracticingCertificate = practicingCertificateSplitPath[1];
-      this.practicingCertFileUploadPath = practicingCertificateSplitPath[0];
-    }
-    else {
-      console.log('-- RQ NOT getting practicing certificate from ANYWHERE');
-    }
-
-    // @TODO: see above, its returning a promise instead of the value!!
-
-    // Path to FileUpload component: /exercise/gWHwfBAlA9JYqzhwELnx/user/UhG4MVCdVpbSZAyZHOgB2LIidFj2
-    // Filename to FileUpload component: exemption-certificate.docx
-
-    console.log('-- RQ Eventual formData:');
-    console.log(this.formData);
-
-    // @TODO: Similar to above check for existing files in candidate record and load it if nowt in the formData (ie the application)!
-
+    this.initQualifications();
+    this.initCertificates();
   },
   methods: {
+    /**
+     * Check if candidate has filled relevant qualifications before
+     */
+    initQualifications() {
+      const candidateRelevantQualifications = this.$store.getters['candidate/relevantQualifications']();
+      if (!this.formData.qualifications && candidateRelevantQualifications?.qualifications) {
+        this.formData.qualifications = candidateRelevantQualifications?.qualifications;
+      }
+    },
+    /**
+     * Initialise certificate file names and paths based on whether the data should come from the application or the candidate records
+     */
+    initCertificates() {
+      const exemptionCertificateSplitPath = getExemptionCertificateSplitPath();
+      const practicingCertificateSplitPath = getPracticingCertificateSplitPath();
+      this.exemptionCertFileUploadPath = this.uploadPath;
+      this.practicingCertFileUploadPath = this.uploadPath;
+      if ((!_has(this.formData, 'uploadedExemptionCertificate') || !this.formData.uploadedExemptionCertificate) && exemptionCertificateSplitPath.length === 2) {
+        this.formData.uploadedExemptionCertificate = exemptionCertificateSplitPath[1];
+        this.exemptionCertFileUploadPath = exemptionCertificateSplitPath[0];
+      }
+      if ((!_has(this.formData, 'uploadedPracticingCertificate') || !this.formData.uploadedPracticingCertificate) && practicingCertificateSplitPath.length === 2) {
+        this.formData.uploadedPracticingCertificate = practicingCertificateSplitPath[1];
+        this.practicingCertFileUploadPath = practicingCertificateSplitPath[0];
+      }
+    },
     async saveAndValidate() {
       if (this.notCompletedPupillage) {
         if (this.formData.uploadedExemptionCertificate === null && this.formData.uploadedPracticingCertificate === null) {
@@ -482,25 +278,14 @@ export default {
         }
       }
       this.save();
-
-      console.log('-- RQ Process qualifications after save!!');
-
       if (this.formData.qualifications) {
-
-        console.log('-- RQ Process QUALIFICATIONS!!');
-        console.log('this.formData.qualifications:');
-        console.log(this.formData.qualifications);
-
         await updateRelevantQualifications(this.updateCertificates, this.formData.qualifications);
       }
     },
-
     setExemptionCertificateFullPath(value) {
-      console.log(`-- RQ setExemptionCertificateFullPath: ${value}`);
       this.updateCertificates.exemptionCertificateFullPath = value;
     },
     setPracticingCertificateFullPath(value) {
-      console.log(`-- RQ setPracticingCertificateFullPath: ${value}`);
       this.updateCertificates.practicingCertificateFullPath = value;
     },
   },

--- a/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
+++ b/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
@@ -419,10 +419,10 @@ export default {
         //   qualifications: this.formData.qualifications,
         // });
 
-        if (_has(candidateRelevantQualifications, 'uploadedExemptionCertificates') {
+        if (_has(candidateRelevantQualifications, 'uploadedExemptionCertificates')) {
           newRelevantQualifications.uploadedExemptionCertificates = candidateRelevantQualifications.uploadedExemptionCertificates;
         }
-        if (_has(candidateRelevantQualifications, 'uploadedPracticingCertificates') {
+        if (_has(candidateRelevantQualifications, 'uploadedPracticingCertificates')) {
           newRelevantQualifications.uploadedPracticingCertificates = candidateRelevantQualifications.uploadedPracticingCertificates;
         }
         await this.$store.dispatch('candidate/saveRelevantQualifications', newRelevantQualifications);

--- a/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
+++ b/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
@@ -362,7 +362,7 @@ export default {
 
         const candidateRelevantQualifications = this.$store.getters['candidate/relevantQualifications']();
 
-        console.log('candidateRelevantQualifications:');
+        console.log('-- RQ candidateRelevantQualifications:');
         console.log(candidateRelevantQualifications);
 
         // @TODO: ENSURE WHEN THE UPDATE HAPPENS ITS GETTING THE QUALIFICATIONS FROM formData AND THE CERTS FROM HERE
@@ -388,7 +388,7 @@ export default {
 
                 console.log('-- RQ last entry IS NOT EQUAL to new one so updating');
 
-                candidateRelevantQualifications.uploadedExemptionCertificates.push(this.updateCertificates.exemptionCertificateFullPath);
+                //candidateRelevantQualifications.uploadedExemptionCertificates.push(this.updateCertificates.exemptionCertificateFullPath);
               }
               else {
                 console.log('-- RQ last entry IS EQUAL so NOT updating');
@@ -398,14 +398,14 @@ export default {
 
               console.log('-- RQ candidateRelevantQualifications.uploadedExemptionCertificates array is empty so populate');
 
-              candidateRelevantQualifications.uploadedExemptionCertificates = [this.updateCertificates.exemptionCertificateFullPath];
+              //candidateRelevantQualifications.uploadedExemptionCertificates = [this.updateCertificates.exemptionCertificateFullPath];
             }
           }
           else {
 
             console.log('-- RQ candidateRelevantQualifications DOES NOT have uploadedExemptionCertificates array so create it and populate');
 
-            candidateRelevantQualifications.uploadedExemptionCertificates = [this.updateCertificates.exemptionCertificateFullPath];
+            //candidateRelevantQualifications.uploadedExemptionCertificates = [this.updateCertificates.exemptionCertificateFullPath];
           }
 
         // @TODO: Get the relevantQualification details then check/retrieve the uploadedExemptionCertificates and append

--- a/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
+++ b/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
@@ -423,7 +423,7 @@ export default {
         // }
         // await this.$store.dispatch('candidate/saveRelevantQualifications', newRelevantQualifications);
 
-        await updateRelevantQualifications(this.updateCertificatesthis.formData.qualifications);
+        await updateRelevantQualifications(this.updateCertificatesthis, this.formData.qualifications);
       }
     },
 

--- a/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
+++ b/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
@@ -221,96 +221,96 @@ export default {
     console.log('-- RQ Initial formData:');
     console.log(formData);
 
-    // check if candidate has filled relevant qualifications before
-    const candidateRelevantQualifications = this.$store.getters['candidate/relevantQualifications']();
+    // // check if candidate has filled relevant qualifications before
+    // const candidateRelevantQualifications = this.$store.getters['candidate/relevantQualifications']();
 
-    console.log('-- RQ candidateRelevantQualifications:');
-    console.log(candidateRelevantQualifications);
+    // console.log('-- RQ candidateRelevantQualifications:');
+    // console.log(candidateRelevantQualifications);
 
-    if (!formData.qualifications && candidateRelevantQualifications?.qualifications) {
-      formData.qualifications = candidateRelevantQualifications?.qualifications;
-    }
+    // if (!formData.qualifications && candidateRelevantQualifications?.qualifications) {
+    //   formData.qualifications = candidateRelevantQualifications?.qualifications;
+    // }
 
-    // @TODO: Certificates
-    const exemptionCertificateSplitPath = getExemptionCertificateSplitPath();
-    console.log('-- RQ exemptionCertificateSplitPath:');
-    console.log(exemptionCertificateSplitPath);
-    if (exemptionCertificateSplitPath.length > 0) {
-      // eg /exercise/gWHwfBAlA9JYqzhwELnx/user/UhG4MVCdVpbSZAyZHOgB2LIidFj
-      console.log(`-- RQ exemptionCertificateSplitPath[0]: ${exemptionCertificateSplitPath[0]}`);
+    // // @TODO: Certificates
+    // const exemptionCertificateSplitPath = getExemptionCertificateSplitPath();
+    // console.log('-- RQ exemptionCertificateSplitPath:');
+    // console.log(exemptionCertificateSplitPath);
+    // if (exemptionCertificateSplitPath.length > 0) {
+    //   // eg /exercise/gWHwfBAlA9JYqzhwELnx/user/UhG4MVCdVpbSZAyZHOgB2LIidFj
+    //   console.log(`-- RQ exemptionCertificateSplitPath[0]: ${exemptionCertificateSplitPath[0]}`);
 
-      // eg exemption-certificate.docx
-      console.log(`-- RQ exemptionCertificateSplitPath[1]: ${exemptionCertificateSplitPath[1]}`);
-    }
+    //   // eg exemption-certificate.docx
+    //   console.log(`-- RQ exemptionCertificateSplitPath[1]: ${exemptionCertificateSplitPath[1]}`);
+    // }
 
-    const practicingCertificateSplitPath = getPracticingCertificateSplitPath();
-    console.log('-- RQ practicingCertificateSplitPath:');
-    console.log(practicingCertificateSplitPath);
-    if (practicingCertificateSplitPath.length > 0) {
-      // eg /exercise/gWHwfBAlA9JYqzhwELnx/user/UhG4MVCdVpbSZAyZHOgB2LIidFj
-      console.log(`-- RQ practicingCertificateSplitPath[0]: ${practicingCertificateSplitPath[0]}`);
+    // const practicingCertificateSplitPath = getPracticingCertificateSplitPath();
+    // console.log('-- RQ practicingCertificateSplitPath:');
+    // console.log(practicingCertificateSplitPath);
+    // if (practicingCertificateSplitPath.length > 0) {
+    //   // eg /exercise/gWHwfBAlA9JYqzhwELnx/user/UhG4MVCdVpbSZAyZHOgB2LIidFj
+    //   console.log(`-- RQ practicingCertificateSplitPath[0]: ${practicingCertificateSplitPath[0]}`);
 
-      // eg practicing-certificate.docx
-      console.log(`-- RQ practicingCertificateSplitPath[1]: ${practicingCertificateSplitPath[1]}`);
-    }
+    //   // eg practicing-certificate.docx
+    //   console.log(`-- RQ practicingCertificateSplitPath[1]: ${practicingCertificateSplitPath[1]}`);
+    // }
 
-    // Check if the application has the uploadedExemptionCertificate set and, if so, use it
-    //    Set the path for the FileUpload component (and formData.uploadedPracticingCertificate is already set!)
-    //    => const fileUploadPath = this.uploadPath;
-    // Else if its in the candidate record
-    //    formData.uploadedPracticingCertificate = exemptionCertificateSplitPath[1]
-    //    fileUploadPath = exemptionCertificateSplitPath[0]
+    // // Check if the application has the uploadedExemptionCertificate set and, if so, use it
+    // //    Set the path for the FileUpload component (and formData.uploadedPracticingCertificate is already set!)
+    // //    => const fileUploadPath = this.uploadPath;
+    // // Else if its in the candidate record
+    // //    formData.uploadedPracticingCertificate = exemptionCertificateSplitPath[1]
+    // //    fileUploadPath = exemptionCertificateSplitPath[0]
 
-    let exemptionCertFileUploadPath = this.uploadPath;
-    let practicingCertFileUploadPath = this.uploadPath;
+    // let exemptionCertFileUploadPath = this.uploadPath;
+    // let practicingCertFileUploadPath = this.uploadPath;
 
-    console.log(`-- RQ THIS.UPLOADPATH: ${this.uploadPath}`);
+    // console.log(`-- RQ THIS.UPLOADPATH: ${this.uploadPath}`);
 
-    // console.log(`-- formData['uploadedExemptionCertificate']: ${formData['uploadedExemptionCertificate']}`);
-    // console.log(`-- exemptionCertificateSplitPath.length']: ${exemptionCertificateSplitPath.length}`);
+    // // console.log(`-- formData['uploadedExemptionCertificate']: ${formData['uploadedExemptionCertificate']}`);
+    // // console.log(`-- exemptionCertificateSplitPath.length']: ${exemptionCertificateSplitPath.length}`);
 
-    // EXEMPTION CERTIFICATE
-    if (_has(formData, 'uploadedExemptionCertificate') && formData.uploadedExemptionCertificate) {
-      console.log('-- RQ Getting exemption certificate from the APPLICATION');
-      console.log(`-- RQ exemptionCertFileUploadPath: ${exemptionCertFileUploadPath}`);
-    }
-    else if ((!_has(formData, 'uploadedExemptionCertificate') || !formData.uploadedExemptionCertificate) && exemptionCertificateSplitPath.length === 2) {
-      console.log('-- RQ Getting exemption certificate from the CANDIDATE PROFILE');
+    // // EXEMPTION CERTIFICATE
+    // if (_has(formData, 'uploadedExemptionCertificate') && formData.uploadedExemptionCertificate) {
+    //   console.log('-- RQ Getting exemption certificate from the APPLICATION');
+    //   console.log(`-- RQ exemptionCertFileUploadPath: ${exemptionCertFileUploadPath}`);
+    // }
+    // else if ((!_has(formData, 'uploadedExemptionCertificate') || !formData.uploadedExemptionCertificate) && exemptionCertificateSplitPath.length === 2) {
+    //   console.log('-- RQ Getting exemption certificate from the CANDIDATE PROFILE');
 
-      // @TODO: COMMENTED OUT BELOW TO SHOW WHAT THE DATA LOOKS LIKE, NOW NEED TO TEST IT WHEN THIS IS UNCOMMENTED AND ENSURE THE FILE STILL SHOWS IN FILE UPLOAD!!
+    //   // @TODO: COMMENTED OUT BELOW TO SHOW WHAT THE DATA LOOKS LIKE, NOW NEED TO TEST IT WHEN THIS IS UNCOMMENTED AND ENSURE THE FILE STILL SHOWS IN FILE UPLOAD!!
 
-      formData.uploadedExemptionCertificate = exemptionCertificateSplitPath[1];
-      exemptionCertFileUploadPath = exemptionCertificateSplitPath[0];
-    }
-    else {
-      console.log('-- RQ NOT getting exemption certificate from ANYWHERE');
-    }
+    //   formData.uploadedExemptionCertificate = exemptionCertificateSplitPath[1];
+    //   exemptionCertFileUploadPath = exemptionCertificateSplitPath[0];
+    // }
+    // else {
+    //   console.log('-- RQ NOT getting exemption certificate from ANYWHERE');
+    // }
 
-    // PRACTICING CERTIFICATE
-    if (_has(formData, 'uploadedPracticingCertificate') && formData.uploadedPracticingCertificate) {
-      console.log('-- RQ Getting practicing certificate from the APPLICATION');
-    }
-    else if ((!_has(formData, 'uploadedPracticingCertificate') || !formData.uploadedPracticingCertificate) && practicingCertificateSplitPath.length === 2) {
-      console.log('-- RQ Getting practicing certificate from the CANDIDATE PROFILE');
+    // // PRACTICING CERTIFICATE
+    // if (_has(formData, 'uploadedPracticingCertificate') && formData.uploadedPracticingCertificate) {
+    //   console.log('-- RQ Getting practicing certificate from the APPLICATION');
+    // }
+    // else if ((!_has(formData, 'uploadedPracticingCertificate') || !formData.uploadedPracticingCertificate) && practicingCertificateSplitPath.length === 2) {
+    //   console.log('-- RQ Getting practicing certificate from the CANDIDATE PROFILE');
 
-      // @TODO: COMMENTED OUT BELOW TO SHOW WHAT THE DATA LOOKS LIKE, NOW NEED TO TEST IT WHEN THIS IS UNCOMMENTED AND ENSURE THE FILE STILL SHOWS IN FILE UPLOAD!!
+    //   // @TODO: COMMENTED OUT BELOW TO SHOW WHAT THE DATA LOOKS LIKE, NOW NEED TO TEST IT WHEN THIS IS UNCOMMENTED AND ENSURE THE FILE STILL SHOWS IN FILE UPLOAD!!
 
-      formData.uploadedPracticingCertificate = practicingCertificateSplitPath[1];
-      practicingCertFileUploadPath = practicingCertificateSplitPath[0];
-    }
-    else {
-      console.log('-- RQ NOT getting practicing certificate from ANYWHERE');
-    }
+    //   formData.uploadedPracticingCertificate = practicingCertificateSplitPath[1];
+    //   practicingCertFileUploadPath = practicingCertificateSplitPath[0];
+    // }
+    // else {
+    //   console.log('-- RQ NOT getting practicing certificate from ANYWHERE');
+    // }
 
-    // @TODO: see above, its returning a promise instead of the value!!
+    // // @TODO: see above, its returning a promise instead of the value!!
 
-    // Path to FileUpload component: /exercise/gWHwfBAlA9JYqzhwELnx/user/UhG4MVCdVpbSZAyZHOgB2LIidFj2
-    // Filename to FileUpload component: exemption-certificate.docx
+    // // Path to FileUpload component: /exercise/gWHwfBAlA9JYqzhwELnx/user/UhG4MVCdVpbSZAyZHOgB2LIidFj2
+    // // Filename to FileUpload component: exemption-certificate.docx
 
-    console.log('-- RQ Eventual formData:');
-    console.log(formData);
+    // console.log('-- RQ Eventual formData:');
+    // console.log(formData);
 
-    // @TODO: Similar to above check for existing files in candidate record and load it if nowt in the formData (ie the application)!
+    // // @TODO: Similar to above check for existing files in candidate record and load it if nowt in the formData (ie the application)!
 
     return {
       formId: 'relevantQualifications',
@@ -324,8 +324,8 @@ export default {
         practicingCertificateFullPath: null,
       },
       errorMessage: '',
-      exemptionCertFileUploadPath: exemptionCertFileUploadPath,
-      practicingCertFileUploadPath: practicingCertFileUploadPath,
+      exemptionCertFileUploadPath: '',
+      practicingCertFileUploadPath: '',
     };
   },
   computed: {
@@ -362,6 +362,113 @@ export default {
         });
       }
     },
+  },
+  created() {
+    // const data = this.$store.getters['application/data'](this.defaults);
+
+    // console.log('============ RELEVANT QUALIFICATION ===============');
+
+    // // - when testing switch between .docx and .doc files!
+
+    // console.log('-- RQ Application data:');
+    // console.log(data);
+
+    // //this.formData = { ...this.defaults, ...data };
+
+    // console.log('-- RQ Initial formData:');
+    // console.log(this.formData);
+
+    // check if candidate has filled relevant qualifications before
+    const candidateRelevantQualifications = this.$store.getters['candidate/relevantQualifications']();
+
+    console.log('-- RQ candidateRelevantQualifications:');
+    console.log(candidateRelevantQualifications);
+
+    if (!this.formData.qualifications && candidateRelevantQualifications?.qualifications) {
+      this.formData.qualifications = candidateRelevantQualifications?.qualifications;
+    }
+
+    // @TODO: Certificates
+    const exemptionCertificateSplitPath = getExemptionCertificateSplitPath();
+    console.log('-- RQ exemptionCertificateSplitPath:');
+    console.log(exemptionCertificateSplitPath);
+    if (exemptionCertificateSplitPath.length > 0) {
+      // eg /exercise/gWHwfBAlA9JYqzhwELnx/user/UhG4MVCdVpbSZAyZHOgB2LIidFj
+      console.log(`-- RQ exemptionCertificateSplitPath[0]: ${exemptionCertificateSplitPath[0]}`);
+
+      // eg exemption-certificate.docx
+      console.log(`-- RQ exemptionCertificateSplitPath[1]: ${exemptionCertificateSplitPath[1]}`);
+    }
+
+    const practicingCertificateSplitPath = getPracticingCertificateSplitPath();
+    console.log('-- RQ practicingCertificateSplitPath:');
+    console.log(practicingCertificateSplitPath);
+    if (practicingCertificateSplitPath.length > 0) {
+      // eg /exercise/gWHwfBAlA9JYqzhwELnx/user/UhG4MVCdVpbSZAyZHOgB2LIidFj
+      console.log(`-- RQ practicingCertificateSplitPath[0]: ${practicingCertificateSplitPath[0]}`);
+
+      // eg practicing-certificate.docx
+      console.log(`-- RQ practicingCertificateSplitPath[1]: ${practicingCertificateSplitPath[1]}`);
+    }
+
+    // Check if the application has the uploadedExemptionCertificate set and, if so, use it
+    //    Set the path for the FileUpload component (and formData.uploadedPracticingCertificate is already set!)
+    //    => const fileUploadPath = this.uploadPath;
+    // Else if its in the candidate record
+    //    formData.uploadedPracticingCertificate = exemptionCertificateSplitPath[1]
+    //    fileUploadPath = exemptionCertificateSplitPath[0]
+
+    this.exemptionCertFileUploadPath = this.uploadPath;
+    this.practicingCertFileUploadPath = this.uploadPath;
+
+    console.log(`-- RQ THIS.UPLOADPATH: ${this.uploadPath}`);
+
+    // console.log(`-- formData['uploadedExemptionCertificate']: ${formData['uploadedExemptionCertificate']}`);
+    // console.log(`-- exemptionCertificateSplitPath.length']: ${exemptionCertificateSplitPath.length}`);
+
+    // EXEMPTION CERTIFICATE
+    if (_has(this.formData, 'uploadedExemptionCertificate') && this.formData.uploadedExemptionCertificate) {
+      console.log('-- RQ Getting exemption certificate from the APPLICATION');
+      console.log(`-- RQ exemptionCertFileUploadPath: ${this.exemptionCertFileUploadPath}`);
+    }
+    else if ((!_has(this.formData, 'uploadedExemptionCertificate') || !this.formData.uploadedExemptionCertificate) && exemptionCertificateSplitPath.length === 2) {
+      console.log('-- RQ Getting exemption certificate from the CANDIDATE PROFILE');
+
+      // @TODO: COMMENTED OUT BELOW TO SHOW WHAT THE DATA LOOKS LIKE, NOW NEED TO TEST IT WHEN THIS IS UNCOMMENTED AND ENSURE THE FILE STILL SHOWS IN FILE UPLOAD!!
+
+      this.formData.uploadedExemptionCertificate = exemptionCertificateSplitPath[1];
+      this.exemptionCertFileUploadPath = exemptionCertificateSplitPath[0];
+    }
+    else {
+      console.log('-- RQ NOT getting exemption certificate from ANYWHERE');
+    }
+
+    // PRACTICING CERTIFICATE
+    if (_has(this.formData, 'uploadedPracticingCertificate') && this.formData.uploadedPracticingCertificate) {
+      console.log('-- RQ Getting practicing certificate from the APPLICATION');
+    }
+    else if ((!_has(this.formData, 'uploadedPracticingCertificate') || !this.formData.uploadedPracticingCertificate) && practicingCertificateSplitPath.length === 2) {
+      console.log('-- RQ Getting practicing certificate from the CANDIDATE PROFILE');
+
+      // @TODO: COMMENTED OUT BELOW TO SHOW WHAT THE DATA LOOKS LIKE, NOW NEED TO TEST IT WHEN THIS IS UNCOMMENTED AND ENSURE THE FILE STILL SHOWS IN FILE UPLOAD!!
+
+      this.formData.uploadedPracticingCertificate = practicingCertificateSplitPath[1];
+      this.practicingCertFileUploadPath = practicingCertificateSplitPath[0];
+    }
+    else {
+      console.log('-- RQ NOT getting practicing certificate from ANYWHERE');
+    }
+
+    // @TODO: see above, its returning a promise instead of the value!!
+
+    // Path to FileUpload component: /exercise/gWHwfBAlA9JYqzhwELnx/user/UhG4MVCdVpbSZAyZHOgB2LIidFj2
+    // Filename to FileUpload component: exemption-certificate.docx
+
+    console.log('-- RQ Eventual formData:');
+    console.log(this.formData);
+
+    // @TODO: Similar to above check for existing files in candidate record and load it if nowt in the formData (ie the application)!
+
   },
   methods: {
     async saveAndValidate() {

--- a/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
+++ b/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
@@ -237,7 +237,7 @@ export default {
 
     let fileUploadPath = this.uploadPath;
 
-    console.log(`-- this.formData['uploadedExemptionCertificate']: ${this.formData['uploadedExemptionCertificate']}`);
+    console.log(`-- formData['uploadedExemptionCertificate']: ${formData['uploadedExemptionCertificate']}`);
     console.log(`-- exemptionCertificateSplitPath.length']: ${exemptionCertificateSplitPath.length}`);
 
     if ((!_has(this.formData, 'uploadedExemptionCertificate') || !formData.uploadedExemptionCertificate) && exemptionCertificateSplitPath.length === 2) {

--- a/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
+++ b/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
@@ -423,7 +423,7 @@ export default {
         // }
         // await this.$store.dispatch('candidate/saveRelevantQualifications', newRelevantQualifications);
 
-        await updateRelevantQualifications(this.updateCertificatesthis, this.formData.qualifications);
+        await updateRelevantQualifications(this.updateCertificates, this.formData.qualifications);
       }
     },
 

--- a/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
+++ b/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
@@ -356,15 +356,54 @@ export default {
         console.log(this.formData.qualifications);
         // @TODO: Save the certs below too!
 
-        await this.$store.dispatch('candidate/saveRelevantQualifications', {
+        const newRelevantQualifications = {
           qualifications: this.formData.qualifications,
-        });
-      }
-      if (this.updateCertificates.exemptionCertificateFullPath) {
-        // Exemption certificate has been added/updated so update the candidate profile
-        console.log('-- RQ exemption certificate has been added/updated so update the candidate profile');
+        };
 
-        // @TODO: Get the relevantQualification details then check/retrieve the uploadedExemptionCewrtificates and append
+        const candidateRelevantQualifications = this.$store.getters['candidate/relevantQualifications']();
+
+        if (this.updateCertificates.exemptionCertificateFullPath) {
+          // Exemption certificate has been added/updated so update the candidate profile
+          console.log('-- RQ exemption certificate has been added/updated so update the candidate profile');
+
+          if (_has(candidateRelevantQualifications, 'uploadedExemptionCertificates')) {
+
+            console.log('-- RQ candidateRelevantQualifications HAS uploadedExemptionCertificates array');
+
+            if (candidateRelevantQualifications.uploadedExemptionCertificates.length > 0) {
+
+              console.log('-- RQ candidateRelevantQualifications.uploadedExemptionCertificates array is not empty so checking last entry');
+
+              const latestEntry = candidateRelevantQualifications.uploadedExemptionCertificates[candidateRelevantQualifications.uploadedExemptionCertificates.length - 1];
+
+              console.log('-- RQ last entry:');
+              console.log(latestEntry);
+
+              if (latestEntry !== this.updateCertificates.exemptionCertificateFullPath) {
+
+                console.log('-- RQ last entry IS NOT EQUAL to new one so updating');
+
+                candidateRelevantQualifications.uploadedExemptionCertificates.push(this.updateCertificates.exemptionCertificateFullPath);
+              }
+              else {
+                console.log('-- RQ last entry IS EQUAL so NOT updating');
+              }
+            }
+            else {
+
+              console.log('-- RQ candidateRelevantQualifications.uploadedExemptionCertificates array is empty so populate');
+
+              candidateRelevantQualifications.uploadedExemptionCertificates = [this.updateCertificates.exemptionCertificateFullPath];
+            }
+          }
+          else {
+
+            console.log('-- RQ candidateRelevantQualifications DOES NOT have uploadedExemptionCertificates array so create it and populate');
+
+            candidateRelevantQualifications.uploadedExemptionCertificates = [this.updateCertificates.exemptionCertificateFullPath];
+          }
+
+        // @TODO: Get the relevantQualification details then check/retrieve the uploadedExemptionCertificates and append
         // this new filepath to it if it's not the latest one on the stack then call the following action in
         // candidates store: saveRelevantQualifications
 
@@ -374,11 +413,17 @@ export default {
         // - use a helper function to save this filepath and retrieve it (get/set)
         // - retrieve the filepath above when the page loads so it fetches the file from the candidate profile if its unset in the application!
 
-      }
-      if (this.updateCertificates.practicingCertificateFullPath) {
-        // Practicing certificate has been added/updated so update the candidate profile
-        console.log('-- RQ practicing certificate has been added/updated so update the candidate profile');
+        }
+        if (this.updateCertificates.practicingCertificateFullPath) {
+          // Practicing certificate has been added/updated so update the candidate profile
+          console.log('-- RQ practicing certificate has been added/updated so update the candidate profile');
 
+        }
+
+        // await this.$store.dispatch('candidate/saveRelevantQualifications', {
+        //   qualifications: this.formData.qualifications,
+        // });
+        await this.$store.dispatch('candidate/saveRelevantQualifications', newRelevantQualifications);
       }
     },
 

--- a/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
+++ b/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
@@ -258,6 +258,13 @@ export default {
         });
       }
     },
+
+    // @TODO:
+    // - should be able to leave application record as it is in terms of how it stroes and retrieves the file
+    // name and uses it in FileUpload component. Just need to store the full path in the candidate record then if we're
+    // using this value for the file upload we split the path accordingly
+    // - note that the uploaded file isnt appearing when the page is refreshed!!
+
     setExemptionCertificateFullPath(value) {
       console.log(`setExemptionCertificateFullPath: ${value}`);
     },

--- a/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
+++ b/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
@@ -264,6 +264,8 @@ export default {
     let exemptionCertFileUploadPath = this.uploadPath;
     let practicingCertFileUploadPath = this.uploadPath;
 
+    console.log(`-- RQ THIS.UPLOADPATH: ${this.uploadPath}`);
+
     // console.log(`-- formData['uploadedExemptionCertificate']: ${formData['uploadedExemptionCertificate']}`);
     // console.log(`-- exemptionCertificateSplitPath.length']: ${exemptionCertificateSplitPath.length}`);
 

--- a/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
+++ b/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
@@ -388,7 +388,7 @@ export default {
 
                 console.log('-- RQ last entry IS NOT EQUAL to new one so updating');
 
-                //candidateRelevantQualifications.uploadedExemptionCertificates.push(this.updateCertificates.exemptionCertificateFullPath);
+                candidateRelevantQualifications.uploadedExemptionCertificates.push(this.updateCertificates.exemptionCertificateFullPath);
               }
               else {
                 console.log('-- RQ last entry IS EQUAL so NOT updating');
@@ -398,25 +398,15 @@ export default {
 
               console.log('-- RQ candidateRelevantQualifications.uploadedExemptionCertificates array is empty so populate');
 
-              //candidateRelevantQualifications.uploadedExemptionCertificates = [this.updateCertificates.exemptionCertificateFullPath];
+              candidateRelevantQualifications.uploadedExemptionCertificates = [this.updateCertificates.exemptionCertificateFullPath];
             }
           }
           else {
 
             console.log('-- RQ candidateRelevantQualifications DOES NOT have uploadedExemptionCertificates array so create it and populate');
 
-            //candidateRelevantQualifications.uploadedExemptionCertificates = [this.updateCertificates.exemptionCertificateFullPath];
+            candidateRelevantQualifications.uploadedExemptionCertificates = [this.updateCertificates.exemptionCertificateFullPath];
           }
-
-        // @TODO: Get the relevantQualification details then check/retrieve the uploadedExemptionCertificates and append
-        // this new filepath to it if it's not the latest one on the stack then call the following action in
-        // candidates store: saveRelevantQualifications
-
-        // @TODO:
-        // - Save under 'relevantQualifications' as an array AND check that saving qualifications doesnt overwrite these file paths
-        // - latest one is the current one so only update it if it's different
-        // - use a helper function to save this filepath and retrieve it (get/set)
-        // - retrieve the filepath above when the page loads so it fetches the file from the candidate profile if its unset in the application!
 
         }
         if (this.updateCertificates.practicingCertificateFullPath) {
@@ -428,6 +418,13 @@ export default {
         // await this.$store.dispatch('candidate/saveRelevantQualifications', {
         //   qualifications: this.formData.qualifications,
         // });
+
+        if (_has(candidateRelevantQualifications, 'uploadedExemptionCertificates') {
+          newRelevantQualifications.uploadedExemptionCertificates = candidateRelevantQualifications.uploadedExemptionCertificates;
+        }
+        if (_has(candidateRelevantQualifications, 'uploadedPracticingCertificates') {
+          newRelevantQualifications.uploadedPracticingCertificates = candidateRelevantQualifications.uploadedPracticingCertificates;
+        }
         await this.$store.dispatch('candidate/saveRelevantQualifications', newRelevantQualifications);
       }
     },

--- a/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
+++ b/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
@@ -183,18 +183,20 @@ export default {
     };
     const data = this.$store.getters['application/data'](defaults);
 
-    console.log('Application data:');
+    console.log('============ RELEVANT QUALIFICATION ===============');
+
+    console.log('-- RQ Application data:');
     console.log(data);
 
     const formData = { ...defaults, ...data };
 
-    console.log('Initial formData:');
+    console.log('-- RQ Initial formData:');
     console.log(formData);
 
     // check if candidate has filled relevant qualifications before
     const candidateRelevantQualifications = this.$store.getters['candidate/relevantQualifications']();
 
-    console.log('candidateRelevantQualifications:');
+    console.log('-- RQ candidateRelevantQualifications:');
     console.log(candidateRelevantQualifications);
 
     if (!formData.qualifications && candidateRelevantQualifications?.qualifications) {
@@ -203,28 +205,26 @@ export default {
 
     // @TODO: Certificates
     const exemptionCertificateSplitPath = getExemptionCertificateSplitPath();
-    console.log('exemptionCertificateSplitPath:');
+    console.log('-- RQ exemptionCertificateSplitPath:');
     console.log(exemptionCertificateSplitPath);
+    if (exemptionCertificateSplitPath.length > 0) {
+      // eg /exercise/gWHwfBAlA9JYqzhwELnx/user/UhG4MVCdVpbSZAyZHOgB2LIidFj
+      console.log(`-- RQ exemptionCertificateSplitPath[0]: ${exemptionCertificateSplitPath[0]}`);
 
-    // eg /exercise/gWHwfBAlA9JYqzhwELnx/user/UhG4MVCdVpbSZAyZHOgB2LIidFj
-    console.log('exemptionCertificateSplitPath[0]:');
-    console.log(exemptionCertificateSplitPath[0]);
-
-    // eg exemption-certificate.docx
-    console.log('exemptionCertificateSplitPath[1]:');
-    console.log(exemptionCertificateSplitPath[1]);
+      // eg exemption-certificate.docx
+      console.log(`-- RQ exemptionCertificateSplitPath[1]: ${exemptionCertificateSplitPath[1]}`);
+    }
 
     const practicingCertificateSplitPath = getPracticingCertificateSplitPath();
-    console.log('practicingCertificateSplitPath:');
+    console.log('-- RQ practicingCertificateSplitPath:');
     console.log(practicingCertificateSplitPath);
+    if (practicingCertificateSplitPath.length > 0) {
+      // eg /exercise/gWHwfBAlA9JYqzhwELnx/user/UhG4MVCdVpbSZAyZHOgB2LIidFj
+      console.log(`-- RQ practicingCertificateSplitPath[0]: ${practicingCertificateSplitPath[0]}`);
 
-    // eg /exercise/gWHwfBAlA9JYqzhwELnx/user/UhG4MVCdVpbSZAyZHOgB2LIidFj
-    console.log('practicingCertificateSplitPath[0]:');
-    console.log(practicingCertificateSplitPath[0]);
-
-    // eg practicing-certificate.docx
-    console.log('practicingCertificateSplitPath[1]:');
-    console.log(practicingCertificateSplitPath[1]);
+      // eg practicing-certificate.docx
+      console.log(`-- RQ practicingCertificateSplitPath[1]: ${practicingCertificateSplitPath[1]}`);
+    }
 
     // Check if the application has the uploadedExemptionCertificate set and, if so, use it
     //    Set the path for the FileUpload component (and formData.uploadedPracticingCertificate is already set!)
@@ -241,24 +241,24 @@ export default {
 
     if ((!_has(formData, 'uploadedExemptionCertificate') || !formData.uploadedExemptionCertificate) && exemptionCertificateSplitPath.length === 2) {
 
-      console.log('-- Getting exemption certificate from the CANDIDATE PROFILE');
+      console.log('-- RQ Getting exemption certificate from the CANDIDATE PROFILE');
 
       //formData.uploadedExemptionCertificate = exemptionCertificateSplitPath[1];
       exemptionCertFileUploadPath = exemptionCertificateSplitPath[0];
     }
     else {
-      console.log('-- Getting exemption certificate from the APPLICATION');
+      console.log('-- RQ Getting exemption certificate from the APPLICATION');
     }
 
     if ((!_has(formData, 'uploadedPracticingCertificate') || !formData.uploadedPracticingCertificate) && practicingCertificateSplitPath.length === 2) {
 
-      console.log('-- Getting practicing certificate from the CANDIDATE PROFILE');
+      console.log('-- RQ Getting practicing certificate from the CANDIDATE PROFILE');
 
       //formData.uploadedPracticingCertificate = practicingCertificateSplitPath[1];
       practicingCertFileUploadPath = practicingCertificateSplitPath[0];
     }
     else {
-      console.log('-- Getting practicing certificate from the APPLICATION');
+      console.log('-- RQ Getting practicing certificate from the APPLICATION');
     }
 
     // @TODO: see above, its returning a promise instead of the value!!
@@ -273,7 +273,7 @@ export default {
     //   formData.qualifications = candidateRelevantQualifications?.qualifications;
     // }
 
-    console.log('Eventual formData:');
+    console.log('-- RQ Eventual formData:');
     console.log(formData);
 
     // @TODO: Similar to above check for existing files in candidate record and load it if nowt in the formData (ie the application)!
@@ -373,11 +373,11 @@ export default {
     // **** CURRENTLY CHECKING THE DATA COMING INTO AND OUT OF THE FILE UPLOAD COMPONENT TO SEE WHY THE FILE NAME ISNT BEING DISPLAYED
 
     setExemptionCertificateFullPath(value) {
-      console.log(`setExemptionCertificateFullPath: ${value}`);
+      console.log(`-- RQ setExemptionCertificateFullPath: ${value}`);
       this.updateCertificates.exemptionCertificateFullPath = value;
     },
     setPracticingCertificateFullPath(value) {
-      console.log(`setPracticingCertificateFullPath: ${value}`);
+      console.log(`-- RQ setPracticingCertificateFullPath: ${value}`);
       this.updateCertificates.practicingCertificateFullPath = value;
     },
   },

--- a/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
+++ b/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
@@ -362,6 +362,11 @@ export default {
 
         const candidateRelevantQualifications = this.$store.getters['candidate/relevantQualifications']();
 
+        console.log('candidateRelevantQualifications:');
+        console.log(candidateRelevantQualifications);
+
+        // @TODO: ENSURE WHEN THE UPDATE HAPPENS ITS GETTING THE QUALIFICATIONS FROM formData AND THE CERTS FROM HERE
+
         if (this.updateCertificates.exemptionCertificateFullPath) {
           // Exemption certificate has been added/updated so update the candidate profile
           console.log('-- RQ exemption certificate has been added/updated so update the candidate profile');

--- a/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
+++ b/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
@@ -236,7 +236,7 @@ export default {
     //    fileUploadPath = exemptionCertificateSplitPath[0]
 
     let fileUploadPath = this.uploadPath;
-    if (!_has(this.formData, 'uploadedExemptionCertificate') || !formData.uploadedExemptionCertificate && exemptionCertificateSplitPath.length === 2) {
+    if ((!_has(this.formData, 'uploadedExemptionCertificate') || !formData.uploadedExemptionCertificate) && exemptionCertificateSplitPath.length === 2) {
 
       console.log('-- Getting exemption certificate from the candidate profile');
 

--- a/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
+++ b/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
@@ -110,6 +110,7 @@
             :acceptable-extensions="['docx', 'doc', 'odt', 'txt', 'fodt', 'pdf']"
             label="Exemption certificate"
             :required="isPupillageCertificateRequired"
+            @uploaded-full-path="setExemptionCertificateFullPath"
           />
 
           <FileUpload
@@ -121,6 +122,7 @@
             :acceptable-extensions="['docx', 'doc', 'odt', 'txt', 'fodt', 'pdf']"
             label="Practicing certificate"
             :required="isPupillageCertificateRequired"
+            @uploaded-full-path="setPracticingCertificateFullPath"
           />
 
           <FormFieldError
@@ -188,6 +190,9 @@ export default {
     if (!formData.qualifications && candidateRelevantQualifications?.qualifications) {
       formData.qualifications = candidateRelevantQualifications?.qualifications;
     }
+
+    // @TODO: Similar to above check for existing files in candidate record and load it if nowt in the formData (ie the application)!
+
     return {
       formId: 'relevantQualifications',
       formData: formData,
@@ -245,11 +250,19 @@ export default {
       }
       this.save();
       if (this.formData.qualifications) {
+
+        // @TODO: Save the certs below too!
+
         await this.$store.dispatch('candidate/saveRelevantQualifications', {
           qualifications: this.formData.qualifications,
         });
       }
-
+    },
+    setExemptionCertificateFullPath(value) {
+      console.log(`setExemptionCertificateFullPath: ${value}`);
+    },
+    setPracticingCertificateFullPath(value) {
+      console.log(`setPracticingCertificateFullPath: ${value}`);
     },
   },
 };

--- a/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
+++ b/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
@@ -354,85 +354,14 @@ export default {
         console.log('-- RQ Process QUALIFICATIONS!!');
         console.log('this.formData.qualifications:');
         console.log(this.formData.qualifications);
-        // @TODO: Save the certs below too!
-
-        // const newRelevantQualifications = {
-        //   qualifications: this.formData.qualifications,
-        // };
-
-        // const candidateRelevantQualifications = this.$store.getters['candidate/relevantQualifications']();
-
-        // console.log('-- RQ candidateRelevantQualifications:');
-        // console.log(candidateRelevantQualifications);
-
-        // @TODO: ENSURE WHEN THE UPDATE HAPPENS ITS GETTING THE QUALIFICATIONS FROM formData AND THE CERTS FROM HERE
-
-        // if (this.updateCertificates.exemptionCertificateFullPath) {
-        //   // Exemption certificate has been added/updated so update the candidate profile
-        //   console.log('-- RQ exemption certificate has been added/updated so update the candidate profile');
-
-        //   if (_has(candidateRelevantQualifications, 'uploadedExemptionCertificates')) {
-
-        //     console.log('-- RQ candidateRelevantQualifications HAS uploadedExemptionCertificates array');
-
-        //     if (candidateRelevantQualifications.uploadedExemptionCertificates.length > 0) {
-
-        //       console.log('-- RQ candidateRelevantQualifications.uploadedExemptionCertificates array is not empty so checking last entry');
-
-        //       const latestEntry = candidateRelevantQualifications.uploadedExemptionCertificates[candidateRelevantQualifications.uploadedExemptionCertificates.length - 1];
-
-        //       console.log('-- RQ last entry:');
-        //       console.log(latestEntry);
-
-        //       if (latestEntry !== this.updateCertificates.exemptionCertificateFullPath) {
-
-        //         console.log('-- RQ last entry IS NOT EQUAL to new one so updating');
-
-        //         candidateRelevantQualifications.uploadedExemptionCertificates.push(this.updateCertificates.exemptionCertificateFullPath);
-        //       }
-        //       else {
-        //         console.log('-- RQ last entry IS EQUAL so NOT updating');
-        //       }
-        //     }
-        //     else {
-
-        //       console.log('-- RQ candidateRelevantQualifications.uploadedExemptionCertificates array is empty so populate');
-
-        //       candidateRelevantQualifications.uploadedExemptionCertificates = [this.updateCertificates.exemptionCertificateFullPath];
-        //     }
-        //   }
-        //   else {
-
-        //     console.log('-- RQ candidateRelevantQualifications DOES NOT have uploadedExemptionCertificates array so create it and populate');
-
-        //     candidateRelevantQualifications.uploadedExemptionCertificates = [this.updateCertificates.exemptionCertificateFullPath];
-        //   }
-
-        // }
-        // if (this.updateCertificates.practicingCertificateFullPath) {
-        //   // Practicing certificate has been added/updated so update the candidate profile
-        //   console.log('-- RQ practicing certificate has been added/updated so update the candidate profile');
-
-        // }
-
-        // if (_has(candidateRelevantQualifications, 'uploadedExemptionCertificates')) {
-        //   newRelevantQualifications.uploadedExemptionCertificates = candidateRelevantQualifications.uploadedExemptionCertificates;
-        // }
-        // if (_has(candidateRelevantQualifications, 'uploadedPracticingCertificates')) {
-        //   newRelevantQualifications.uploadedPracticingCertificates = candidateRelevantQualifications.uploadedPracticingCertificates;
-        // }
-        // await this.$store.dispatch('candidate/saveRelevantQualifications', newRelevantQualifications);
 
         await updateRelevantQualifications(this.updateCertificates, this.formData.qualifications);
+
+        // @TODO: get the loading of the cert working from the candidate profile (see stuff commented out above!)
+        // - when testing switch between .docx and .doc files!
+
       }
     },
-
-    // @TODO:
-    // - should be able to leave application record as it is in terms of how it stores and retrieves the file
-    // name and uses it in FileUpload component. Just need to store the full path in the candidate record then if we're
-    // using this value for the file upload we split the path accordingly
-    // - note that the uploaded file isnt appearing when the page is refreshed!!
-    // **** CURRENTLY CHECKING THE DATA COMING INTO AND OUT OF THE FILE UPLOAD COMPONENT TO SEE WHY THE FILE NAME ISNT BEING DISPLAYED
 
     setExemptionCertificateFullPath(value) {
       console.log(`-- RQ setExemptionCertificateFullPath: ${value}`);

--- a/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
+++ b/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
@@ -156,6 +156,7 @@ import * as filters from '@/filters';
 import FileUpload from '@/components/Form/FileUpload.vue';
 import FormFieldError from '@/components/Form/FormFieldError.vue';
 import _has from 'lodash/has';
+import { getExemptionCertificateSplitPath } from '@/services/candidateService';
 
 export default {
   name: 'RelevantQualifications',
@@ -183,21 +184,38 @@ export default {
       progress: {},
     };
     const data = this.$store.getters['application/data'](defaults);
-    const formData = { ...defaults, ...data };
-
-    // check if candidate has filled relevant qualifications before
-    const candidateRelevantQualifications = this.$store.getters['candidate/relevantQualifications']();
-    if (!formData.qualifications && candidateRelevantQualifications?.qualifications) {
-      formData.qualifications = candidateRelevantQualifications?.qualifications;
-    }
 
     console.log('Application data:');
     console.log(data);
 
+    const formData = { ...defaults, ...data };
+
+    console.log('Initial formData:');
+    console.log(formData);
+
+    // check if candidate has filled relevant qualifications before
+    const candidateRelevantQualifications = this.$store.getters['candidate/relevantQualifications']();
+
     console.log('candidateRelevantQualifications:');
     console.log(candidateRelevantQualifications);
 
-    console.log('formData:');
+    if (!formData.qualifications && candidateRelevantQualifications?.qualifications) {
+      formData.qualifications = candidateRelevantQualifications?.qualifications;
+    }
+
+    // @TODO: Certificates
+    const exemptionCertificateSplitPath = getExemptionCertificateSplitPath();
+    console.log('exemptionCertificateSplitPath:');
+    console.log(exemptionCertificateSplitPath);
+
+    // if (!formData.exemptionCertificateFullPath && candidateRelevantQualifications?.qualifications) {
+    //   formData.uploadedExemptionCertificate = candidateRelevantQualifications?.qualifications;
+    // }
+    // if (!formData.qualifications && candidateRelevantQualifications?.qualifications) {
+    //   formData.qualifications = candidateRelevantQualifications?.qualifications;
+    // }
+
+    console.log('Eventual formData:');
     console.log(formData);
 
     // @TODO: Similar to above check for existing files in candidate record and load it if nowt in the formData (ie the application)!
@@ -207,6 +225,11 @@ export default {
       formData: formData,
       repeatableFields: {
         Qualification,
+      },
+      // Save full path to candidate profile when updating certificates
+      updateCertificates: {
+        exemptionCertificateFullPath: null,
+        practicingCertificateFullPath: null,
       },
       errorMessage: '',
     };
@@ -266,6 +289,20 @@ export default {
           qualifications: this.formData.qualifications,
         });
       }
+      if (this.updateCertificates.exemptionCertificateFullPath) {
+        // Exemption certificate has been added/updated so update the candidate profile
+
+        // @TODO:
+        // - Save under 'relevantQualifications' as an array AND check that saving qualifications doesnt overwrite these file paths
+        // - latest one is the current one so only update it if it's different
+        // - use a helper function to save this filepath and retrieve it (get/set)
+        // - retrieve the filepath above when the page loads so it fetches the file from the candidate profile if its unset in the application!
+
+      }
+      if (this.updateCertificates.exemptionCertificateFullPath) {
+        // Practicing certificate has been added/updated so update the candidate profile
+
+      }
     },
 
     // @TODO:
@@ -277,9 +314,11 @@ export default {
 
     setExemptionCertificateFullPath(value) {
       console.log(`setExemptionCertificateFullPath: ${value}`);
+      this.updateCertificates.exemptionCertificateFullPath = value;
     },
     setPracticingCertificateFullPath(value) {
       console.log(`setPracticingCertificateFullPath: ${value}`);
+      this.updateCertificates.practicingCertificateFullPath = value;
     },
   },
 };

--- a/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
+++ b/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
@@ -356,14 +356,14 @@ export default {
         console.log(this.formData.qualifications);
         // @TODO: Save the certs below too!
 
-        const newRelevantQualifications = {
-          qualifications: this.formData.qualifications,
-        };
+        // const newRelevantQualifications = {
+        //   qualifications: this.formData.qualifications,
+        // };
 
-        const candidateRelevantQualifications = this.$store.getters['candidate/relevantQualifications']();
+        // const candidateRelevantQualifications = this.$store.getters['candidate/relevantQualifications']();
 
-        console.log('-- RQ candidateRelevantQualifications:');
-        console.log(candidateRelevantQualifications);
+        // console.log('-- RQ candidateRelevantQualifications:');
+        // console.log(candidateRelevantQualifications);
 
         // @TODO: ENSURE WHEN THE UPDATE HAPPENS ITS GETTING THE QUALIFICATIONS FROM formData AND THE CERTS FROM HERE
 

--- a/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
+++ b/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
@@ -191,6 +191,15 @@ export default {
       formData.qualifications = candidateRelevantQualifications?.qualifications;
     }
 
+    console.log('Application data:');
+    console.log(data);
+
+    console.log('candidateRelevantQualifications:');
+    console.log(candidateRelevantQualifications);
+
+    console.log('formData:');
+    console.log(formData);
+
     // @TODO: Similar to above check for existing files in candidate record and load it if nowt in the formData (ie the application)!
 
     return {
@@ -260,10 +269,11 @@ export default {
     },
 
     // @TODO:
-    // - should be able to leave application record as it is in terms of how it stroes and retrieves the file
+    // - should be able to leave application record as it is in terms of how it stores and retrieves the file
     // name and uses it in FileUpload component. Just need to store the full path in the candidate record then if we're
     // using this value for the file upload we split the path accordingly
     // - note that the uploaded file isnt appearing when the page is refreshed!!
+    // **** CURRENTLY CHECKING THE DATA COMING INTO AND OUT OF THE FILE UPLOAD COMPONENT TO SEE WHY THE FILE NAME ISNT BEING DISPLAYED
 
     setExemptionCertificateFullPath(value) {
       console.log(`setExemptionCertificateFullPath: ${value}`);

--- a/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
+++ b/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
@@ -240,7 +240,7 @@ export default {
     console.log(`-- formData['uploadedExemptionCertificate']: ${formData['uploadedExemptionCertificate']}`);
     console.log(`-- exemptionCertificateSplitPath.length']: ${exemptionCertificateSplitPath.length}`);
 
-    if ((!_has(this.formData, 'uploadedExemptionCertificate') || !formData.uploadedExemptionCertificate) && exemptionCertificateSplitPath.length === 2) {
+    if ((!_has(formData, 'uploadedExemptionCertificate') || !formData.uploadedExemptionCertificate) && exemptionCertificateSplitPath.length === 2) {
 
       console.log('-- Getting exemption certificate from the candidate profile');
 

--- a/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
+++ b/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
@@ -156,7 +156,7 @@ import * as filters from '@/filters';
 import FileUpload from '@/components/Form/FileUpload.vue';
 import FormFieldError from '@/components/Form/FormFieldError.vue';
 import _has from 'lodash/has';
-import { getExemptionCertificateSplitPath, getPracticingCertificateSplitPath } from '@/services/candidateService';
+import { getExemptionCertificateSplitPath, getPracticingCertificateSplitPath, updateRelevantQualifications } from '@/services/candidateService';
 
 export default {
   name: 'RelevantQualifications',
@@ -367,65 +367,63 @@ export default {
 
         // @TODO: ENSURE WHEN THE UPDATE HAPPENS ITS GETTING THE QUALIFICATIONS FROM formData AND THE CERTS FROM HERE
 
-        if (this.updateCertificates.exemptionCertificateFullPath) {
-          // Exemption certificate has been added/updated so update the candidate profile
-          console.log('-- RQ exemption certificate has been added/updated so update the candidate profile');
+        // if (this.updateCertificates.exemptionCertificateFullPath) {
+        //   // Exemption certificate has been added/updated so update the candidate profile
+        //   console.log('-- RQ exemption certificate has been added/updated so update the candidate profile');
 
-          if (_has(candidateRelevantQualifications, 'uploadedExemptionCertificates')) {
+        //   if (_has(candidateRelevantQualifications, 'uploadedExemptionCertificates')) {
 
-            console.log('-- RQ candidateRelevantQualifications HAS uploadedExemptionCertificates array');
+        //     console.log('-- RQ candidateRelevantQualifications HAS uploadedExemptionCertificates array');
 
-            if (candidateRelevantQualifications.uploadedExemptionCertificates.length > 0) {
+        //     if (candidateRelevantQualifications.uploadedExemptionCertificates.length > 0) {
 
-              console.log('-- RQ candidateRelevantQualifications.uploadedExemptionCertificates array is not empty so checking last entry');
+        //       console.log('-- RQ candidateRelevantQualifications.uploadedExemptionCertificates array is not empty so checking last entry');
 
-              const latestEntry = candidateRelevantQualifications.uploadedExemptionCertificates[candidateRelevantQualifications.uploadedExemptionCertificates.length - 1];
+        //       const latestEntry = candidateRelevantQualifications.uploadedExemptionCertificates[candidateRelevantQualifications.uploadedExemptionCertificates.length - 1];
 
-              console.log('-- RQ last entry:');
-              console.log(latestEntry);
+        //       console.log('-- RQ last entry:');
+        //       console.log(latestEntry);
 
-              if (latestEntry !== this.updateCertificates.exemptionCertificateFullPath) {
+        //       if (latestEntry !== this.updateCertificates.exemptionCertificateFullPath) {
 
-                console.log('-- RQ last entry IS NOT EQUAL to new one so updating');
+        //         console.log('-- RQ last entry IS NOT EQUAL to new one so updating');
 
-                candidateRelevantQualifications.uploadedExemptionCertificates.push(this.updateCertificates.exemptionCertificateFullPath);
-              }
-              else {
-                console.log('-- RQ last entry IS EQUAL so NOT updating');
-              }
-            }
-            else {
+        //         candidateRelevantQualifications.uploadedExemptionCertificates.push(this.updateCertificates.exemptionCertificateFullPath);
+        //       }
+        //       else {
+        //         console.log('-- RQ last entry IS EQUAL so NOT updating');
+        //       }
+        //     }
+        //     else {
 
-              console.log('-- RQ candidateRelevantQualifications.uploadedExemptionCertificates array is empty so populate');
+        //       console.log('-- RQ candidateRelevantQualifications.uploadedExemptionCertificates array is empty so populate');
 
-              candidateRelevantQualifications.uploadedExemptionCertificates = [this.updateCertificates.exemptionCertificateFullPath];
-            }
-          }
-          else {
+        //       candidateRelevantQualifications.uploadedExemptionCertificates = [this.updateCertificates.exemptionCertificateFullPath];
+        //     }
+        //   }
+        //   else {
 
-            console.log('-- RQ candidateRelevantQualifications DOES NOT have uploadedExemptionCertificates array so create it and populate');
+        //     console.log('-- RQ candidateRelevantQualifications DOES NOT have uploadedExemptionCertificates array so create it and populate');
 
-            candidateRelevantQualifications.uploadedExemptionCertificates = [this.updateCertificates.exemptionCertificateFullPath];
-          }
+        //     candidateRelevantQualifications.uploadedExemptionCertificates = [this.updateCertificates.exemptionCertificateFullPath];
+        //   }
 
-        }
-        if (this.updateCertificates.practicingCertificateFullPath) {
-          // Practicing certificate has been added/updated so update the candidate profile
-          console.log('-- RQ practicing certificate has been added/updated so update the candidate profile');
+        // }
+        // if (this.updateCertificates.practicingCertificateFullPath) {
+        //   // Practicing certificate has been added/updated so update the candidate profile
+        //   console.log('-- RQ practicing certificate has been added/updated so update the candidate profile');
 
-        }
+        // }
 
-        // await this.$store.dispatch('candidate/saveRelevantQualifications', {
-        //   qualifications: this.formData.qualifications,
-        // });
+        // if (_has(candidateRelevantQualifications, 'uploadedExemptionCertificates')) {
+        //   newRelevantQualifications.uploadedExemptionCertificates = candidateRelevantQualifications.uploadedExemptionCertificates;
+        // }
+        // if (_has(candidateRelevantQualifications, 'uploadedPracticingCertificates')) {
+        //   newRelevantQualifications.uploadedPracticingCertificates = candidateRelevantQualifications.uploadedPracticingCertificates;
+        // }
+        // await this.$store.dispatch('candidate/saveRelevantQualifications', newRelevantQualifications);
 
-        if (_has(candidateRelevantQualifications, 'uploadedExemptionCertificates')) {
-          newRelevantQualifications.uploadedExemptionCertificates = candidateRelevantQualifications.uploadedExemptionCertificates;
-        }
-        if (_has(candidateRelevantQualifications, 'uploadedPracticingCertificates')) {
-          newRelevantQualifications.uploadedPracticingCertificates = candidateRelevantQualifications.uploadedPracticingCertificates;
-        }
-        await this.$store.dispatch('candidate/saveRelevantQualifications', newRelevantQualifications);
+        await updateRelevantQualifications(this.updateCertificatesthis.formData.qualifications);
       }
     },
 

--- a/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
+++ b/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
@@ -101,7 +101,7 @@
         <template v-if="notCompletedPupillage">
           <h2>As you did not complete pupillage, please provide a copy of your exemption and or practicing certificate</h2>
 
-          <!-- <FileUpload
+          <FileUpload
             id="exemption-certificate-upload"
             ref="exemption-certificate"
             v-model="formData.uploadedExemptionCertificate"
@@ -110,7 +110,6 @@
             :acceptable-extensions="['docx', 'doc', 'odt', 'txt', 'fodt', 'pdf']"
             label="Exemption certificate"
             :required="isPupillageCertificateRequired"
-            @uploaded-file-path="setExemptionCertificateFullPath"
           />
 
           <FileUpload
@@ -122,31 +121,6 @@
             :acceptable-extensions="['docx', 'doc', 'odt', 'txt', 'fodt', 'pdf']"
             label="Practicing certificate"
             :required="isPupillageCertificateRequired"
-            @uploaded-file-path="setPracticingCertificateFullPath"
-          /> -->
-
-          <FileUpload
-            id="exemption-certificate-upload"
-            ref="exemption-certificate"
-            v-model="formData.uploadedExemptionCertificate"
-            name="exemption-certificate"
-            :path="exemptionCertFileUploadPath"
-            :acceptable-extensions="['docx', 'doc', 'odt', 'txt', 'fodt', 'pdf']"
-            label="Exemption certificate"
-            :required="isPupillageCertificateRequired"
-            @uploaded-file-path="setExemptionCertificateFullPath"
-          />
-
-          <FileUpload
-            id="practicing-certificate-upload"
-            ref="practicing-certificate"
-            v-model="formData.uploadedPracticingCertificate"
-            name="practicing-certificate"
-            :path="practicingCertFileUploadPath"
-            :acceptable-extensions="['docx', 'doc', 'odt', 'txt', 'fodt', 'pdf']"
-            label="Practicing certificate"
-            :required="isPupillageCertificateRequired"
-            @uploaded-file-path="setPracticingCertificateFullPath"
           />
 
           <FormFieldError
@@ -180,7 +154,6 @@ import * as filters from '@/filters';
 import FileUpload from '@/components/Form/FileUpload.vue';
 import FormFieldError from '@/components/Form/FormFieldError.vue';
 import _has from 'lodash/has';
-import { getExemptionCertificateSplitPath, getPracticingCertificateSplitPath } from '@/services/candidateService';
 
 export default {
   name: 'RelevantQualifications',
@@ -208,116 +181,20 @@ export default {
       progress: {},
     };
     const data = this.$store.getters['application/data'](defaults);
-
-    console.log('Application data:');
-    console.log(data);
-
     const formData = { ...defaults, ...data };
-
-    console.log('Initial formData:');
-    console.log(formData);
 
     // check if candidate has filled relevant qualifications before
     const candidateRelevantQualifications = this.$store.getters['candidate/relevantQualifications']();
-
-    console.log('candidateRelevantQualifications:');
-    console.log(candidateRelevantQualifications);
-
     if (!formData.qualifications && candidateRelevantQualifications?.qualifications) {
       formData.qualifications = candidateRelevantQualifications?.qualifications;
     }
-
-    // @TODO: Certificates
-    const exemptionCertificateSplitPath = getExemptionCertificateSplitPath();
-    console.log('exemptionCertificateSplitPath:');
-    console.log(exemptionCertificateSplitPath);
-
-    // eg /exercise/gWHwfBAlA9JYqzhwELnx/user/UhG4MVCdVpbSZAyZHOgB2LIidFj
-    console.log('exemptionCertificateSplitPath[0]:');
-    console.log(exemptionCertificateSplitPath[0]);
-
-    // eg exemption-certificate.docx
-    console.log('exemptionCertificateSplitPath[1]:');
-    console.log(exemptionCertificateSplitPath[1]);
-
-    const practicingCertificateSplitPath = getPracticingCertificateSplitPath();
-    console.log('practicingCertificateSplitPath:');
-    console.log(practicingCertificateSplitPath);
-
-    // eg /exercise/gWHwfBAlA9JYqzhwELnx/user/UhG4MVCdVpbSZAyZHOgB2LIidFj
-    console.log('practicingCertificateSplitPath[0]:');
-    console.log(practicingCertificateSplitPath[0]);
-
-    // eg practicing-certificate.docx
-    console.log('practicingCertificateSplitPath[1]:');
-    console.log(practicingCertificateSplitPath[1]);
-
-    // Check if the application has the uploadedExemptionCertificate set and, if so, use it
-    //    Set the path for the FileUpload component (and formData.uploadedPracticingCertificate is already set!)
-    //    => const fileUploadPath = this.uploadPath;
-    // Else if its in the candidate record
-    //    formData.uploadedPracticingCertificate = exemptionCertificateSplitPath[1]
-    //    fileUploadPath = exemptionCertificateSplitPath[0]
-
-    let exemptionCertFileUploadPath = this.uploadPath;
-    let practicingCertFileUploadPath = this.uploadPath;
-
-    // console.log(`-- formData['uploadedExemptionCertificate']: ${formData['uploadedExemptionCertificate']}`);
-    // console.log(`-- exemptionCertificateSplitPath.length']: ${exemptionCertificateSplitPath.length}`);
-
-    if ((!_has(formData, 'uploadedExemptionCertificate') || !formData.uploadedExemptionCertificate) && exemptionCertificateSplitPath.length === 2) {
-
-      console.log('-- Getting exemption certificate from the CANDIDATE PROFILE');
-
-      formData.uploadedExemptionCertificate = exemptionCertificateSplitPath[1];
-      exemptionCertFileUploadPath = exemptionCertificateSplitPath[0];
-    }
-    else {
-      console.log('-- Getting exemption certificate from the APPLICATION');
-    }
-
-    if ((!_has(formData, 'uploadedPracticingCertificate') || !formData.uploadedPracticingCertificate) && practicingCertificateSplitPath.length === 2) {
-
-      console.log('-- Getting practicing certificate from the CANDIDATE PROFILE');
-
-      formData.uploadedPracticingCertificate = practicingCertificateSplitPath[1];
-      practicingCertFileUploadPath = practicingCertificateSplitPath[0];
-    }
-    else {
-      console.log('-- Getting practicing certificate from the APPLICATION');
-    }
-
-    // @TODO: see above, its returning a promise instead of the value!!
-
-    // Path to FileUpload component: /exercise/gWHwfBAlA9JYqzhwELnx/user/UhG4MVCdVpbSZAyZHOgB2LIidFj2
-    // Filename to FileUpload component: exemption-certificate.docx
-
-    // if (!formData.exemptionCertificateFullPath && candidateRelevantQualifications?.qualifications) {
-    //   formData.uploadedExemptionCertificate = candidateRelevantQualifications?.qualifications;
-    // }
-    // if (!formData.qualifications && candidateRelevantQualifications?.qualifications) {
-    //   formData.qualifications = candidateRelevantQualifications?.qualifications;
-    // }
-
-    console.log('Eventual formData:');
-    console.log(formData);
-
-    // @TODO: Similar to above check for existing files in candidate record and load it if nowt in the formData (ie the application)!
-
     return {
       formId: 'relevantQualifications',
       formData: formData,
       repeatableFields: {
         Qualification,
       },
-      // Save full path to candidate profile when updating certificates
-      updateCertificates: {
-        exemptionCertificateFullPath: null,
-        practicingCertificateFullPath: null,
-      },
       errorMessage: '',
-      exemptionCertFileUploadPath: exemptionCertFileUploadPath,
-      practicingCertFileUploadPath: practicingCertFileUploadPath,
     };
   },
   computed: {
@@ -368,43 +245,11 @@ export default {
       }
       this.save();
       if (this.formData.qualifications) {
-
-        // @TODO: Save the certs below too!
-
         await this.$store.dispatch('candidate/saveRelevantQualifications', {
           qualifications: this.formData.qualifications,
         });
       }
-      if (this.updateCertificates.exemptionCertificateFullPath) {
-        // Exemption certificate has been added/updated so update the candidate profile
 
-        // @TODO:
-        // - Save under 'relevantQualifications' as an array AND check that saving qualifications doesnt overwrite these file paths
-        // - latest one is the current one so only update it if it's different
-        // - use a helper function to save this filepath and retrieve it (get/set)
-        // - retrieve the filepath above when the page loads so it fetches the file from the candidate profile if its unset in the application!
-
-      }
-      if (this.updateCertificates.exemptionCertificateFullPath) {
-        // Practicing certificate has been added/updated so update the candidate profile
-
-      }
-    },
-
-    // @TODO:
-    // - should be able to leave application record as it is in terms of how it stores and retrieves the file
-    // name and uses it in FileUpload component. Just need to store the full path in the candidate record then if we're
-    // using this value for the file upload we split the path accordingly
-    // - note that the uploaded file isnt appearing when the page is refreshed!!
-    // **** CURRENTLY CHECKING THE DATA COMING INTO AND OUT OF THE FILE UPLOAD COMPONENT TO SEE WHY THE FILE NAME ISNT BEING DISPLAYED
-
-    setExemptionCertificateFullPath(value) {
-      console.log(`setExemptionCertificateFullPath: ${value}`);
-      this.updateCertificates.exemptionCertificateFullPath = value;
-    },
-    setPracticingCertificateFullPath(value) {
-      console.log(`setPracticingCertificateFullPath: ${value}`);
-      this.updateCertificates.practicingCertificateFullPath = value;
     },
   },
 };

--- a/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
+++ b/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
@@ -351,6 +351,7 @@ export default {
 
       if (this.formData.qualifications) {
 
+        console.log('-- RQ Process QUALIFICATIONS!!');
         // @TODO: Save the certs below too!
 
         await this.$store.dispatch('candidate/saveRelevantQualifications', {

--- a/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
+++ b/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
@@ -208,6 +208,15 @@ export default {
     console.log('exemptionCertificateSplitPath:');
     console.log(exemptionCertificateSplitPath);
 
+    console.log('exemptionCertificateSplitPath[0]:');
+    console.log(exemptionCertificateSplitPath[0]);
+
+    console.log('exemptionCertificateSplitPath[1]:');
+    console.log(exemptionCertificateSplitPath[1]);
+
+    // Path to FileUpload component: /exercise/gWHwfBAlA9JYqzhwELnx/user/UhG4MVCdVpbSZAyZHOgB2LIidFj2
+    // Filename to FileUpload component: exemption-certificate.docx
+
     // if (!formData.exemptionCertificateFullPath && candidateRelevantQualifications?.qualifications) {
     //   formData.uploadedExemptionCertificate = candidateRelevantQualifications?.qualifications;
     // }

--- a/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
+++ b/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
@@ -111,6 +111,18 @@
             label="Exemption certificate"
             :required="isPupillageCertificateRequired"
             @uploaded-file-path="setExemptionCertificateFullPath"
+          />
+
+          <FileUpload
+            id="practicing-certificate-upload"
+            ref="practicing-certificate"
+            v-model="formData.uploadedPracticingCertificate"
+            name="practicing-certificate"
+            :path="uploadPath"
+            :acceptable-extensions="['docx', 'doc', 'odt', 'txt', 'fodt', 'pdf']"
+            label="Practicing certificate"
+            :required="isPupillageCertificateRequired"
+            @uploaded-file-path="setPracticingCertificateFullPath"
           /> -->
 
           <FileUpload
@@ -118,7 +130,7 @@
             ref="exemption-certificate"
             v-model="formData.uploadedExemptionCertificate"
             name="exemption-certificate"
-            :path="fileUploadPath"
+            :path="exemptionCertFileUploadPath"
             :acceptable-extensions="['docx', 'doc', 'odt', 'txt', 'fodt', 'pdf']"
             label="Exemption certificate"
             :required="isPupillageCertificateRequired"
@@ -130,7 +142,7 @@
             ref="practicing-certificate"
             v-model="formData.uploadedPracticingCertificate"
             name="practicing-certificate"
-            :path="uploadPath"
+            :path="practicingCertFileUploadPath"
             :acceptable-extensions="['docx', 'doc', 'odt', 'txt', 'fodt', 'pdf']"
             label="Practicing certificate"
             :required="isPupillageCertificateRequired"
@@ -168,7 +180,7 @@ import * as filters from '@/filters';
 import FileUpload from '@/components/Form/FileUpload.vue';
 import FormFieldError from '@/components/Form/FormFieldError.vue';
 import _has from 'lodash/has';
-import { getExemptionCertificateSplitPath } from '@/services/candidateService';
+import { getExemptionCertificateSplitPath, getPracticingCertificateSplitPath } from '@/services/candidateService';
 
 export default {
   name: 'RelevantQualifications',
@@ -228,6 +240,18 @@ export default {
     console.log('exemptionCertificateSplitPath[1]:');
     console.log(exemptionCertificateSplitPath[1]);
 
+    const practicingCertificateSplitPath = getPracticingCertificateSplitPath();
+    console.log('practicingCertificateSplitPath:');
+    console.log(practicingCertificateSplitPath);
+
+    // eg /exercise/gWHwfBAlA9JYqzhwELnx/user/UhG4MVCdVpbSZAyZHOgB2LIidFj
+    console.log('practicingCertificateSplitPath[0]:');
+    console.log(practicingCertificateSplitPath[0]);
+
+    // eg practicing-certificate.docx
+    console.log('practicingCertificateSplitPath[1]:');
+    console.log(practicingCertificateSplitPath[1]);
+
     // Check if the application has the uploadedExemptionCertificate set and, if so, use it
     //    Set the path for the FileUpload component (and formData.uploadedPracticingCertificate is already set!)
     //    => const fileUploadPath = this.uploadPath;
@@ -235,20 +259,32 @@ export default {
     //    formData.uploadedPracticingCertificate = exemptionCertificateSplitPath[1]
     //    fileUploadPath = exemptionCertificateSplitPath[0]
 
-    let fileUploadPath = this.uploadPath;
+    let exemptionCertFileUploadPath = this.uploadPath;
+    let practicingCertFileUploadPath = this.uploadPath;
 
-    console.log(`-- formData['uploadedExemptionCertificate']: ${formData['uploadedExemptionCertificate']}`);
-    console.log(`-- exemptionCertificateSplitPath.length']: ${exemptionCertificateSplitPath.length}`);
+    // console.log(`-- formData['uploadedExemptionCertificate']: ${formData['uploadedExemptionCertificate']}`);
+    // console.log(`-- exemptionCertificateSplitPath.length']: ${exemptionCertificateSplitPath.length}`);
 
     if ((!_has(formData, 'uploadedExemptionCertificate') || !formData.uploadedExemptionCertificate) && exemptionCertificateSplitPath.length === 2) {
 
-      console.log('-- Getting exemption certificate from the candidate profile');
+      console.log('-- Getting exemption certificate from the CANDIDATE PROFILE');
 
-      formData.uploadedPracticingCertificate = exemptionCertificateSplitPath[1];
-      fileUploadPath = exemptionCertificateSplitPath[0];
+      formData.uploadedExemptionCertificate = exemptionCertificateSplitPath[1];
+      exemptionCertFileUploadPath = exemptionCertificateSplitPath[0];
     }
     else {
-      console.log('-- NOT Getting exemption certificate from the candidate profile');
+      console.log('-- Getting exemption certificate from the APPLICATION');
+    }
+
+    if ((!_has(formData, 'uploadedPracticingCertificate') || !formData.uploadedPracticingCertificate) && practicingCertificateSplitPath.length === 2) {
+
+      console.log('-- Getting practicing certificate from the CANDIDATE PROFILE');
+
+      formData.uploadedPracticingCertificate = practicingCertificateSplitPath[1];
+      practicingCertFileUploadPath = practicingCertificateSplitPath[0];
+    }
+    else {
+      console.log('-- Getting practicing certificate from the APPLICATION');
     }
 
     // @TODO: see above, its returning a promise instead of the value!!
@@ -280,7 +316,8 @@ export default {
         practicingCertificateFullPath: null,
       },
       errorMessage: '',
-      fileUploadPath: fileUploadPath,
+      exemptionCertFileUploadPath: exemptionCertFileUploadPath,
+      practicingCertFileUploadPath: practicingCertFileUploadPath,
     };
   },
   computed: {

--- a/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
+++ b/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
@@ -110,6 +110,7 @@
             :acceptable-extensions="['docx', 'doc', 'odt', 'txt', 'fodt', 'pdf']"
             label="Exemption certificate"
             :required="isPupillageCertificateRequired"
+            @uploaded-file-path="setExemptionCertificateFullPath"
           />
 
           <FileUpload
@@ -121,6 +122,7 @@
             :acceptable-extensions="['docx', 'doc', 'odt', 'txt', 'fodt', 'pdf']"
             label="Practicing certificate"
             :required="isPupillageCertificateRequired"
+            @uploaded-file-path="setPracticingCertificateFullPath"
           />
 
           <FormFieldError
@@ -344,6 +346,9 @@ export default {
         }
       }
       this.save();
+
+      console.log('-- RQ Process qualifications after save!!');
+
       if (this.formData.qualifications) {
 
         // @TODO: Save the certs below too!
@@ -355,6 +360,10 @@ export default {
       if (this.updateCertificates.exemptionCertificateFullPath) {
         // Exemption certificate has been added/updated so update the candidate profile
         console.log('-- RQ exemption certificate has been added/updated so update the candidate profile');
+
+        // @TODO: Get the relevantQualification details then check/retrieve the uploadedExemptionCewrtificates and append
+        // this new filepath to it if it's not the latest one on the stack then call the following action in
+        // candidates store: saveRelevantQualifications
 
         // @TODO:
         // - Save under 'relevantQualifications' as an array AND check that saving qualifications doesnt overwrite these file paths

--- a/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
+++ b/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
@@ -239,39 +239,42 @@ export default {
     // console.log(`-- formData['uploadedExemptionCertificate']: ${formData['uploadedExemptionCertificate']}`);
     // console.log(`-- exemptionCertificateSplitPath.length']: ${exemptionCertificateSplitPath.length}`);
 
-    if ((!_has(formData, 'uploadedExemptionCertificate') || !formData.uploadedExemptionCertificate) && exemptionCertificateSplitPath.length === 2) {
-
+    // EXEMPTION CERTIFICATE
+    if (_has(formData, 'uploadedExemptionCertificate') && formData.uploadedExemptionCertificate) {
+      console.log('-- RQ Getting exemption certificate from the APPLICATION');
+    }
+    else if ((!_has(formData, 'uploadedExemptionCertificate') || !formData.uploadedExemptionCertificate) && exemptionCertificateSplitPath.length === 2) {
       console.log('-- RQ Getting exemption certificate from the CANDIDATE PROFILE');
+
+      // @TODO: COMMENTED OUT BELOW TO SHOW WHAT THE DATA LOOKS LIKE, NOW NEED TO TEST IT WHEN THIS IS UNCOMMENTED AND ENSURE THE FILE STILL SHOWS IN FILE UPLOAD!!
 
       //formData.uploadedExemptionCertificate = exemptionCertificateSplitPath[1];
       exemptionCertFileUploadPath = exemptionCertificateSplitPath[0];
     }
     else {
-      console.log('-- RQ Getting exemption certificate from the APPLICATION');
+      console.log('-- RQ NOT getting exemption certificate from ANYWHERE');
     }
 
-    if ((!_has(formData, 'uploadedPracticingCertificate') || !formData.uploadedPracticingCertificate) && practicingCertificateSplitPath.length === 2) {
-
+    // PRACTICING CERTIFICATE
+    if (_has(formData, 'uploadedPracticingCertificate') && formData.uploadedPracticingCertificate) {
+      console.log('-- RQ Getting practicing certificate from the APPLICATION');
+    }
+    else if ((!_has(formData, 'uploadedPracticingCertificate') || !formData.uploadedPracticingCertificate) && practicingCertificateSplitPath.length === 2) {
       console.log('-- RQ Getting practicing certificate from the CANDIDATE PROFILE');
+
+      // @TODO: COMMENTED OUT BELOW TO SHOW WHAT THE DATA LOOKS LIKE, NOW NEED TO TEST IT WHEN THIS IS UNCOMMENTED AND ENSURE THE FILE STILL SHOWS IN FILE UPLOAD!!
 
       //formData.uploadedPracticingCertificate = practicingCertificateSplitPath[1];
       practicingCertFileUploadPath = practicingCertificateSplitPath[0];
     }
     else {
-      console.log('-- RQ Getting practicing certificate from the APPLICATION');
+      console.log('-- RQ NOT getting practicing certificate from ANYWHERE');
     }
 
     // @TODO: see above, its returning a promise instead of the value!!
 
     // Path to FileUpload component: /exercise/gWHwfBAlA9JYqzhwELnx/user/UhG4MVCdVpbSZAyZHOgB2LIidFj2
     // Filename to FileUpload component: exemption-certificate.docx
-
-    // if (!formData.exemptionCertificateFullPath && candidateRelevantQualifications?.qualifications) {
-    //   formData.uploadedExemptionCertificate = candidateRelevantQualifications?.qualifications;
-    // }
-    // if (!formData.qualifications && candidateRelevantQualifications?.qualifications) {
-    //   formData.qualifications = candidateRelevantQualifications?.qualifications;
-    // }
 
     console.log('-- RQ Eventual formData:');
     console.log(formData);
@@ -351,6 +354,7 @@ export default {
       }
       if (this.updateCertificates.exemptionCertificateFullPath) {
         // Exemption certificate has been added/updated so update the candidate profile
+        console.log('-- RQ exemption certificate has been added/updated so update the candidate profile');
 
         // @TODO:
         // - Save under 'relevantQualifications' as an array AND check that saving qualifications doesnt overwrite these file paths
@@ -359,8 +363,9 @@ export default {
         // - retrieve the filepath above when the page loads so it fetches the file from the candidate profile if its unset in the application!
 
       }
-      if (this.updateCertificates.exemptionCertificateFullPath) {
+      if (this.updateCertificates.practicingCertificateFullPath) {
         // Practicing certificate has been added/updated so update the candidate profile
+        console.log('-- RQ practicing certificate has been added/updated so update the candidate profile');
 
       }
     },

--- a/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
+++ b/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
@@ -352,6 +352,8 @@ export default {
       if (this.formData.qualifications) {
 
         console.log('-- RQ Process QUALIFICATIONS!!');
+        console.log('this.formData.qualifications:');
+        console.log(this.formData.qualifications);
         // @TODO: Save the certs below too!
 
         await this.$store.dispatch('candidate/saveRelevantQualifications', {

--- a/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
+++ b/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
@@ -236,6 +236,10 @@ export default {
     //    fileUploadPath = exemptionCertificateSplitPath[0]
 
     let fileUploadPath = this.uploadPath;
+
+    console.log(`-- this.formData['uploadedExemptionCertificate']: ${this.formData['uploadedExemptionCertificate']}`);
+    console.log(`-- exemptionCertificateSplitPath.length']: ${exemptionCertificateSplitPath.length}`);
+
     if ((!_has(this.formData, 'uploadedExemptionCertificate') || !formData.uploadedExemptionCertificate) && exemptionCertificateSplitPath.length === 2) {
 
       console.log('-- Getting exemption certificate from the candidate profile');

--- a/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
+++ b/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
@@ -101,7 +101,7 @@
         <template v-if="notCompletedPupillage">
           <h2>As you did not complete pupillage, please provide a copy of your exemption and or practicing certificate</h2>
 
-          <FileUpload
+          <!-- <FileUpload
             id="exemption-certificate-upload"
             ref="exemption-certificate"
             v-model="formData.uploadedExemptionCertificate"
@@ -119,6 +119,30 @@
             v-model="formData.uploadedPracticingCertificate"
             name="practicing-certificate"
             :path="uploadPath"
+            :acceptable-extensions="['docx', 'doc', 'odt', 'txt', 'fodt', 'pdf']"
+            label="Practicing certificate"
+            :required="isPupillageCertificateRequired"
+            @uploaded-file-path="setPracticingCertificateFullPath"
+          /> -->
+
+          <FileUpload
+            id="exemption-certificate-upload"
+            ref="exemption-certificate"
+            v-model="formData.uploadedExemptionCertificate"
+            name="exemption-certificate"
+            :path="exemptionCertFileUploadPath"
+            :acceptable-extensions="['docx', 'doc', 'odt', 'txt', 'fodt', 'pdf']"
+            label="Exemption certificate"
+            :required="isPupillageCertificateRequired"
+            @uploaded-file-path="setExemptionCertificateFullPath"
+          />
+
+          <FileUpload
+            id="practicing-certificate-upload"
+            ref="practicing-certificate"
+            v-model="formData.uploadedPracticingCertificate"
+            name="practicing-certificate"
+            :path="practicingCertFileUploadPath"
             :acceptable-extensions="['docx', 'doc', 'odt', 'txt', 'fodt', 'pdf']"
             label="Practicing certificate"
             :required="isPupillageCertificateRequired"
@@ -187,6 +211,8 @@ export default {
 
     console.log('============ RELEVANT QUALIFICATION ===============');
 
+    // - when testing switch between .docx and .doc files!
+
     console.log('-- RQ Application data:');
     console.log(data);
 
@@ -250,7 +276,7 @@ export default {
 
       // @TODO: COMMENTED OUT BELOW TO SHOW WHAT THE DATA LOOKS LIKE, NOW NEED TO TEST IT WHEN THIS IS UNCOMMENTED AND ENSURE THE FILE STILL SHOWS IN FILE UPLOAD!!
 
-      //formData.uploadedExemptionCertificate = exemptionCertificateSplitPath[1];
+      formData.uploadedExemptionCertificate = exemptionCertificateSplitPath[1];
       exemptionCertFileUploadPath = exemptionCertificateSplitPath[0];
     }
     else {
@@ -266,7 +292,7 @@ export default {
 
       // @TODO: COMMENTED OUT BELOW TO SHOW WHAT THE DATA LOOKS LIKE, NOW NEED TO TEST IT WHEN THIS IS UNCOMMENTED AND ENSURE THE FILE STILL SHOWS IN FILE UPLOAD!!
 
-      //formData.uploadedPracticingCertificate = practicingCertificateSplitPath[1];
+      formData.uploadedPracticingCertificate = practicingCertificateSplitPath[1];
       practicingCertFileUploadPath = practicingCertificateSplitPath[0];
     }
     else {
@@ -356,10 +382,6 @@ export default {
         console.log(this.formData.qualifications);
 
         await updateRelevantQualifications(this.updateCertificates, this.formData.qualifications);
-
-        // @TODO: get the loading of the cert working from the candidate profile (see stuff commented out above!)
-        // - when testing switch between .docx and .doc files!
-
       }
     },
 

--- a/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
+++ b/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
@@ -270,6 +270,7 @@ export default {
     // EXEMPTION CERTIFICATE
     if (_has(formData, 'uploadedExemptionCertificate') && formData.uploadedExemptionCertificate) {
       console.log('-- RQ Getting exemption certificate from the APPLICATION');
+      console.log(`-- RQ exemptionCertFileUploadPath: ${exemptionCertFileUploadPath}`);
     }
     else if ((!_has(formData, 'uploadedExemptionCertificate') || !formData.uploadedExemptionCertificate) && exemptionCertificateSplitPath.length === 2) {
       console.log('-- RQ Getting exemption certificate from the CANDIDATE PROFILE');

--- a/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
+++ b/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
@@ -101,12 +101,24 @@
         <template v-if="notCompletedPupillage">
           <h2>As you did not complete pupillage, please provide a copy of your exemption and or practicing certificate</h2>
 
-          <FileUpload
+          <!-- <FileUpload
             id="exemption-certificate-upload"
             ref="exemption-certificate"
             v-model="formData.uploadedExemptionCertificate"
             name="exemption-certificate"
             :path="uploadPath"
+            :acceptable-extensions="['docx', 'doc', 'odt', 'txt', 'fodt', 'pdf']"
+            label="Exemption certificate"
+            :required="isPupillageCertificateRequired"
+            @uploaded-file-path="setExemptionCertificateFullPath"
+          /> -->
+
+          <FileUpload
+            id="exemption-certificate-upload"
+            ref="exemption-certificate"
+            v-model="formData.uploadedExemptionCertificate"
+            name="exemption-certificate"
+            :path="fileUploadPath"
             :acceptable-extensions="['docx', 'doc', 'odt', 'txt', 'fodt', 'pdf']"
             label="Exemption certificate"
             :required="isPupillageCertificateRequired"
@@ -208,11 +220,34 @@ export default {
     console.log('exemptionCertificateSplitPath:');
     console.log(exemptionCertificateSplitPath);
 
+    // eg /exercise/gWHwfBAlA9JYqzhwELnx/user/UhG4MVCdVpbSZAyZHOgB2LIidFj
     console.log('exemptionCertificateSplitPath[0]:');
     console.log(exemptionCertificateSplitPath[0]);
 
+    // eg exemption-certificate.docx
     console.log('exemptionCertificateSplitPath[1]:');
     console.log(exemptionCertificateSplitPath[1]);
+
+    // Check if the application has the uploadedExemptionCertificate set and, if so, use it
+    //    Set the path for the FileUpload component (and formData.uploadedPracticingCertificate is already set!)
+    //    => const fileUploadPath = this.uploadPath;
+    // Else if its in the candidate record
+    //    formData.uploadedPracticingCertificate = exemptionCertificateSplitPath[1]
+    //    fileUploadPath = exemptionCertificateSplitPath[0]
+
+    let fileUploadPath = this.uploadPath;
+    if (!_has(this.formData, 'uploadedExemptionCertificate') || !formData.uploadedExemptionCertificate && exemptionCertificateSplitPath.length === 2) {
+
+      console.log('-- Getting exemption certificate from the candidate profile');
+
+      formData.uploadedPracticingCertificate = exemptionCertificateSplitPath[1];
+      fileUploadPath = exemptionCertificateSplitPath[0];
+    }
+    else {
+      console.log('-- NOT Getting exemption certificate from the candidate profile');
+    }
+
+    // @TODO: see above, its returning a promise instead of the value!!
 
     // Path to FileUpload component: /exercise/gWHwfBAlA9JYqzhwELnx/user/UhG4MVCdVpbSZAyZHOgB2LIidFj2
     // Filename to FileUpload component: exemption-certificate.docx
@@ -241,6 +276,7 @@ export default {
         practicingCertificateFullPath: null,
       },
       errorMessage: '',
+      fileUploadPath: fileUploadPath,
     };
   },
   computed: {

--- a/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
+++ b/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
@@ -110,7 +110,7 @@
             :acceptable-extensions="['docx', 'doc', 'odt', 'txt', 'fodt', 'pdf']"
             label="Exemption certificate"
             :required="isPupillageCertificateRequired"
-            @uploaded-full-path="setExemptionCertificateFullPath"
+            @uploaded-file-path="setExemptionCertificateFullPath"
           />
 
           <FileUpload
@@ -122,7 +122,7 @@
             :acceptable-extensions="['docx', 'doc', 'odt', 'txt', 'fodt', 'pdf']"
             label="Practicing certificate"
             :required="isPupillageCertificateRequired"
-            @uploaded-full-path="setPracticingCertificateFullPath"
+            @uploaded-file-path="setPracticingCertificateFullPath"
           />
 
           <FormFieldError


### PR DESCRIPTION
## What's included?
Store the practising/exemption certificates alongside the rest of the qualifications data so that the candidate doesnt have to upload them each time they make a new application.

Closes #1253 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
- Go to the following url and login: https://jac-apply-develop--pr1276-feature-1253-include-sdcqc0mu.web.app/
- Apply for a new vacancy
- Go to the relevant qualifications and specify that you are a barrister who has NOT completed pupillage. You will be given the opportunity to upload exemption and practicing certificates. Upload an exemption one only and press 'Save and Continue'
- Apply for a different vacancy
- Go to the relevant qualifications and you should see the form prepoulated and the exemption certificate should be there

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
