### PR TITLE
send verification email once sign-in

### DIFF
--- a/src/views/SignUpStep1.vue
+++ b/src/views/SignUpStep1.vue
@@ -148,8 +148,6 @@ export default {
       await createCandidate({
         email: this.formData.email,
       });
-      // Send email verification
-      await sendEmailVerificationLink();
 
       this.$router.push({ name: 'verify-email-request' });
       return true;

--- a/src/views/VerifyEmailRequest.vue
+++ b/src/views/VerifyEmailRequest.vue
@@ -71,6 +71,11 @@ export default {
       return this.$store.getters['auth/isEmailVerified'];
     },
   },
+  mounted: async function () {
+    if (!this.isEmailVerified) {
+      this.resend();
+    }
+  },
   methods: {
     async resend() {
       this.showEmailVerificationError = false;


### PR DESCRIPTION
## What's included?
Original: The verification email only be sent when creating account (first sign-in).
Expected: The verification email be sent when candidate sign-in if email not verified.

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
- Sign-in with an existing account (not first sign-in) that email not verified.
- The verification email should be sent.

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work


## Additional context
Include screen grabs, notes etc.

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
