### PR TITLE
Bugfix/1291 Qualifications data not stored against candidate profile

### DIFF
--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           ref: ${{ github.event.inputs.version_number }}
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: cache-node-modules
         with:

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: cache-node-modules
         with:
@@ -76,7 +76,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: cache-node-modules
         with:
@@ -124,7 +124,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: cache-node-modules
         with:

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: cache-node-modules
         with:
@@ -77,7 +77,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: cache-node-modules
         with:

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: cache-node-modules
         with:

--- a/src/services/candidateService.js
+++ b/src/services/candidateService.js
@@ -45,47 +45,50 @@ const getPracticingCertificateSplitPath = () => {
  * @param {Array} newQualifications
  */
 const updateRelevantQualifications = async (newCertificateFullPaths, newQualifications = null) => {
-  const relevantQualififcations = store.getters['candidate/relevantQualifications']();
+  let relevantQualifications = store.getters['candidate/relevantQualifications']();
+  if (!relevantQualifications) {
+    relevantQualifications = {};
+  }
   if (newQualifications) {
-    relevantQualififcations.qualifications = newQualifications;
+    relevantQualifications.qualifications = newQualifications;
   }
   // Exemption Certificate
   if (_has(newCertificateFullPaths, 'exemptionCertificateFullPath') && newCertificateFullPaths.exemptionCertificateFullPath) {
     // Exemption certificate has been added/updated so update the candidate profile
-    if (_has(relevantQualififcations, 'uploadedExemptionCertificates')) {
-      if (relevantQualififcations.uploadedExemptionCertificates.length > 0) {
-        const latestEntry = relevantQualififcations.uploadedExemptionCertificates[relevantQualififcations.uploadedExemptionCertificates.length - 1];
+    if (_has(relevantQualifications, 'uploadedExemptionCertificates')) {
+      if (relevantQualifications.uploadedExemptionCertificates.length > 0) {
+        const latestEntry = relevantQualifications.uploadedExemptionCertificates[relevantQualifications.uploadedExemptionCertificates.length - 1];
         if (latestEntry !== newCertificateFullPaths.exemptionCertificateFullPath) {
-          relevantQualififcations.uploadedExemptionCertificates.push(newCertificateFullPaths.exemptionCertificateFullPath);
+          relevantQualifications.uploadedExemptionCertificates.push(newCertificateFullPaths.exemptionCertificateFullPath);
         }
       }
       else {
-        relevantQualififcations.uploadedExemptionCertificates = [newCertificateFullPaths.exemptionCertificateFullPath];
+        relevantQualifications.uploadedExemptionCertificates = [newCertificateFullPaths.exemptionCertificateFullPath];
       }
     }
     else {
-      relevantQualififcations.uploadedExemptionCertificates = [newCertificateFullPaths.exemptionCertificateFullPath];
+      relevantQualifications.uploadedExemptionCertificates = [newCertificateFullPaths.exemptionCertificateFullPath];
     }
   }
   // Practicing Certificate
   if (_has(newCertificateFullPaths, 'practicingCertificateFullPath') && newCertificateFullPaths.practicingCertificateFullPath) {
     // Practicing certificate has been added/updated so update the candidate profile
-    if (_has(relevantQualififcations, 'uploadedPracticingCertificates')) {
-      if (relevantQualififcations.uploadedPracticingCertificates.length > 0) {
-        const latestEntry = relevantQualififcations.uploadedPracticingCertificates[relevantQualififcations.uploadedPracticingCertificates.length - 1];
+    if (_has(relevantQualifications, 'uploadedPracticingCertificates')) {
+      if (relevantQualifications.uploadedPracticingCertificates.length > 0) {
+        const latestEntry = relevantQualifications.uploadedPracticingCertificates[relevantQualifications.uploadedPracticingCertificates.length - 1];
         if (latestEntry !== newCertificateFullPaths.practicingCertificateFullPath) {
-          relevantQualififcations.uploadedPracticingCertificates.push(newCertificateFullPaths.practicingCertificateFullPath);
+          relevantQualifications.uploadedPracticingCertificates.push(newCertificateFullPaths.practicingCertificateFullPath);
         }
       }
       else {
-        relevantQualififcations.uploadedPracticingCertificates = [newCertificateFullPaths.practicingCertificateFullPath];
+        relevantQualifications.uploadedPracticingCertificates = [newCertificateFullPaths.practicingCertificateFullPath];
       }
     }
     else {
-      relevantQualififcations.uploadedPracticingCertificates = [newCertificateFullPaths.practicingCertificateFullPath];
+      relevantQualifications.uploadedPracticingCertificates = [newCertificateFullPaths.practicingCertificateFullPath];
     }
   }
-  await store.dispatch('candidate/saveRelevantQualifications', relevantQualififcations);
+  await store.dispatch('candidate/saveRelevantQualifications', relevantQualifications);
 };
 
 export {

--- a/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
+++ b/src/views/Apply/QualificationsAndExperience/RelevantQualifications.vue
@@ -143,6 +143,7 @@
 </template>
 
 <script>
+import { shallowRef } from 'vue';
 import Form from '@/components/Form/Form.vue';
 import ErrorSummary from '@/components/Form/ErrorSummary.vue';
 import ApplyMixIn from '../ApplyMixIn';
@@ -188,9 +189,9 @@ export default {
     return {
       formId: 'relevantQualifications',
       formData: formData,
-      repeatableFields: {
+      repeatableFields: shallowRef({
         Qualification,
-      },
+      }),
       // Save full path to candidate profile when updating certificates
       updateCertificates: {
         exemptionCertificateFullPath: null,


### PR DESCRIPTION
## What's included?
Closes #1291 

- Fix qualifications data not being stored against the candidate profile.
- Fix the naming.
- Update `actions/cache` version to v4.

## Who should test?
✅ Product owner
✅ Developers

## How to test?

[Exercise 1](https://jac-apply-develop--pr1292-bugfix-1291-qualific-19r772hs.web.app/vacancy/o16kUeHxf8qoEYirg4ca/)
[Exercise 2](https://jac-apply-develop--pr1292-bugfix-1291-qualific-19r772hs.web.app/vacancy/NktLQeNru7YXHkFUAEoF/)

Steps:
1. Apply for Exercise 1 and finish the Relevant qualifications section.
2. Apply for Exercise 2 and check if the qualifications data is populated from the candidate profile. 

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

## Additional context
Demo:

https://github.com/user-attachments/assets/089abbab-d008-4e8f-918b-91877c6b2061

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
