### PR TITLE
#1297 Add Questions To Pre-Existing Exercise

### DIFF
--- a/src/components/Form/QuestionInput.vue
+++ b/src/components/Form/QuestionInput.vue
@@ -4,8 +4,10 @@
       class="govuk-fieldset"
       :aria-describedby="`${id}-hint`"
     >
-      <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-        {{ title }}
+      <legend :class="['govuk-fieldset__legend', { 'govuk-fieldset__legend--m': !isHTMLValue }]">
+        <CustomHTML
+          :value="title"
+        />
       </legend>
       <span
         :id="`${id}-hint`"
@@ -53,6 +55,7 @@ import RankedChoice from '../QuestionInput/RankedChoice.vue';
 import FormField from '@/components/Form/FormField.vue';
 import FormFieldError from '@/components/Form/FormFieldError.vue';
 import { isGapInIntegers } from '@/helpers/array';
+import CustomHTML from '@/components/CustomHTML.vue';
 
 export default {
   compatConfig: {
@@ -66,6 +69,7 @@ export default {
     SingleChoice,
     MultipleChoice,
     RankedChoice,
+    CustomHTML,
   },
   extends: FormField,
   props: {
@@ -160,6 +164,9 @@ export default {
     },
     isRankedChoice() {
       return this.type === 'ranked-choice';
+    },
+    isHTMLValue() {
+      return this.title && this.title.trim().charAt(0) === '<';
     },
   },
   methods: {

--- a/src/components/QuestionInput/QuestionInputView.vue
+++ b/src/components/QuestionInput/QuestionInputView.vue
@@ -2,9 +2,11 @@
   <div
     class="govuk-summary-list__row"
   >
-    <dt class="govuk-summary-list__key">
+    <dt :class="{ 'govuk-summary-list__key': !isHTMLValue }">
       <span v-if="config.topic">{{ config.topic }}<br></span>
-      {{ config.question }}
+      <CustomHTML
+        :value="config.question"
+      />
     </dt>
     <dd
       class="govuk-summary-list__value"
@@ -28,9 +30,13 @@
 
 <script>
 import { extractAnswers } from '@/helpers/workingPreferencesHelper.js';
+import CustomHTML from '@/components/CustomHTML.vue';
 
 export default {
   name: 'QuestionInputView',
+  components: {
+    CustomHTML,
+  },
   props: {
     config: {
       type: Object,
@@ -52,6 +58,9 @@ export default {
     },
     answerData() {
       return extractAnswers(this.config, this.data, this.answerSources, this.$filters);
+    },
+    isHTMLValue() {
+      return this.config.question && this.config.question.trim().charAt(0) === '<';
     },
   },
 };


### PR DESCRIPTION
## What's included?
The 'First-tier Tribunal Medical Members SEC' exercise needs a couple of questions added to it.
We have modified the Additional Working Preferences Questions so that they use rich html inputs to give more control over the appearance of the questions.

- Make the additional working prefs questions use a rich html input
- Ensure questions display correctly.
- Ensure the text isnt bold when the input is html.

Closes #1297 

## Who should test?
✅ Product owner
✅ Developers
✅ UTG

## How to test?
- Go to the following url and apply for the vacancy: https://jac-apply-develop--pr1298-feature-1297-add-que-e8i5ls31.web.app/vacancy/oMVaKLPbEzR89VoJl6yi/
- Ensure the Additional Working Preferences Questions display correctly and can be answered
- To modify them go to the url referenced in the following Admin PR: https://github.com/jac-uk/admin/pull/2711

## Risk - how likely is this to impact other areas?
🟢 No risk - this is a self-contained piece of work

---
PREVIEW:DEVELOP
_can be OFF, DEVELOP or STAGING_
